### PR TITLE
Split RUM context API into stable vs volatile

### DIFF
--- a/src/Runner/Runner.cpp
+++ b/src/Runner/Runner.cpp
@@ -337,45 +337,53 @@ void RunWaitingThreads()
 
 
 // Scenario 5: RUM context view transitions
-void SetView(const std::string& appId, const std::string& sessionId,
-             const char* viewId, const char* viewName)
+void SetSession(const std::string& appId, const std::string& sessionId)
 {
-    RumContextValues ctx = {};
+    RumSessionContext ctx = {};
     ctx.application_id = appId.c_str();
     ctx.session_id = sessionId.c_str();
-    ctx.view_id = viewId;
-    ctx.view_name = viewName;
-    UpdateRumContext(&ctx);
+    SetRumSession(&ctx);
 }
 
-void ClearView(const std::string& appId, const std::string& sessionId)
+void SetView(const char* viewId, const char* viewName)
 {
-    SetView(appId, sessionId, nullptr, nullptr);
+    RumViewValues ctx = {};
+    ctx.view_id = viewId;
+    ctx.view_name = viewName;
+    SetRumView(&ctx);
+}
+
+void ClearView()
+{
+    SetRumView(nullptr);
 }
 
 void RunRumScenario(const std::string& appId, const std::string& sessionId)
 {
     static const std::string sessionId2 = "99999999-2222-3333-4444-555555555555";
 
-    SetView(appId, sessionId, "11111111-1111-1111-1111-111111111111", "HomePage");
+    SetSession(appId, sessionId);
+
+    SetView("11111111-1111-1111-1111-111111111111", "HomePage");
     std::cout << "View 1: HomePage, session S1 (spinning 2s)..." << std::endl;
     Spin(2000);
 
-    ClearView(appId, sessionId);
-    SetView(appId, sessionId, "22222222-2222-2222-2222-222222222222", "SettingsPage");
+    ClearView();
+    SetView("22222222-2222-2222-2222-222222222222", "SettingsPage");
     std::cout << "View 2: SettingsPage, session S1 (spinning 2s)..." << std::endl;
     Spin(2000);
 
-    ClearView(appId, sessionId);
+    ClearView();
     std::cout << "No active view, session S1 (spinning 1s)..." << std::endl;
     Spin(1000);
 
     // Session rotation: switch from S1 to S2
-    SetView(appId, sessionId2, "33333333-3333-3333-3333-333333333333", "ProfilePage");
+    SetSession(appId, sessionId2);
+    SetView("33333333-3333-3333-3333-333333333333", "ProfilePage");
     std::cout << "View 3: ProfilePage, session S2 (spinning 2s)..." << std::endl;
     Spin(2000);
 
-    ClearView(appId, sessionId2);
+    ClearView();
 }
 
 

--- a/src/Tests/RumContextTests.cpp
+++ b/src/Tests/RumContextTests.cpp
@@ -65,18 +65,20 @@ protected:
     std::unique_ptr<Profiler> _profiler;
 };
 
-TEST_F(ProfilerRumContextTest, UpdateRumContextReturnsfalseOnNull) {
-    EXPECT_FALSE(_profiler->UpdateRumContext(nullptr));
+TEST_F(ProfilerRumContextTest, SetRumSessionReturnsFalseOnNull) {
+    EXPECT_FALSE(_profiler->SetRumSession(nullptr));
 }
 
 TEST_F(ProfilerRumContextTest, SetViewContextAndReadBack) {
-    RumContextValues ctx = {};
-    ctx.application_id = "app-id-1";
-    ctx.session_id = "session-id-1";
-    ctx.view_id = "view-id-1";
-    ctx.view_name = "HomePage";
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-id-1";
+    sessionCtx.session_id = "session-id-1";
+    EXPECT_TRUE(_profiler->SetRumSession(&sessionCtx));
 
-    EXPECT_TRUE(_profiler->UpdateRumContext(&ctx));
+    RumViewValues viewVals = {};
+    viewVals.view_id = "view-id-1";
+    viewVals.view_name = "HomePage";
+    _profiler->SetRumView(&viewVals);
 
     RumViewContext viewCtx;
     EXPECT_TRUE(_profiler->GetCurrentViewContext(viewCtx));
@@ -85,62 +87,70 @@ TEST_F(ProfilerRumContextTest, SetViewContextAndReadBack) {
 }
 
 TEST_F(ProfilerRumContextTest, ClearViewWithNullViewId) {
-    // Set a view first
-    RumContextValues ctx = {};
-    ctx.application_id = "app-id-1";
-    ctx.session_id = "session-id-1";
-    ctx.view_id = "view-id-1";
-    ctx.view_name = "HomePage";
-    _profiler->UpdateRumContext(&ctx);
+    // Set a session and view first
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-id-1";
+    sessionCtx.session_id = "session-id-1";
+    _profiler->SetRumSession(&sessionCtx);
+
+    RumViewValues viewVals = {};
+    viewVals.view_id = "view-id-1";
+    viewVals.view_name = "HomePage";
+    _profiler->SetRumView(&viewVals);
 
     // Clear view by passing null view_id
-    RumContextValues clearCtx = {};
-    clearCtx.application_id = "app-id-1";
-    clearCtx.session_id = "session-id-1";
-    clearCtx.view_id = nullptr;
-    clearCtx.view_name = nullptr;
-    EXPECT_TRUE(_profiler->UpdateRumContext(&clearCtx));
+    RumViewValues clearVals = {};
+    clearVals.view_id = nullptr;
+    clearVals.view_name = nullptr;
+    _profiler->SetRumView(&clearVals);
 
     RumViewContext viewCtx;
     EXPECT_FALSE(_profiler->GetCurrentViewContext(viewCtx));
 }
 
 TEST_F(ProfilerRumContextTest, ClearViewWithEmptyViewId) {
-    // Set a view first
-    RumContextValues ctx = {};
-    ctx.application_id = "app-id-1";
-    ctx.session_id = "session-id-1";
-    ctx.view_id = "view-id-1";
-    ctx.view_name = "HomePage";
-    _profiler->UpdateRumContext(&ctx);
+    // Set a session and view first
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-id-1";
+    sessionCtx.session_id = "session-id-1";
+    _profiler->SetRumSession(&sessionCtx);
+
+    RumViewValues viewVals = {};
+    viewVals.view_id = "view-id-1";
+    viewVals.view_name = "HomePage";
+    _profiler->SetRumView(&viewVals);
 
     // Clear view by passing empty view_id
-    RumContextValues clearCtx = {};
-    clearCtx.application_id = "app-id-1";
-    clearCtx.session_id = "session-id-1";
-    clearCtx.view_id = "";
-    clearCtx.view_name = "";
-    EXPECT_TRUE(_profiler->UpdateRumContext(&clearCtx));
+    RumViewValues clearVals = {};
+    clearVals.view_id = "";
+    clearVals.view_name = "";
+    _profiler->SetRumView(&clearVals);
 
     RumViewContext viewCtx;
     EXPECT_FALSE(_profiler->GetCurrentViewContext(viewCtx));
 }
 
 TEST_F(ProfilerRumContextTest, AppIdSetOnce) {
-    RumContextValues ctx1 = {};
-    ctx1.application_id = "app-1";
-    ctx1.session_id = "session-1";
-    ctx1.view_id = "view-1";
-    ctx1.view_name = "Page1";
-    EXPECT_TRUE(_profiler->UpdateRumContext(&ctx1));
+    RumSessionContext sessionCtx1 = {};
+    sessionCtx1.application_id = "app-1";
+    sessionCtx1.session_id = "session-1";
+    EXPECT_TRUE(_profiler->SetRumSession(&sessionCtx1));
+
+    RumViewValues viewVals1 = {};
+    viewVals1.view_id = "view-1";
+    viewVals1.view_name = "Page1";
+    _profiler->SetRumView(&viewVals1);
 
     // Same app_id with different session_id should succeed (session is mutable)
-    RumContextValues ctx1b = {};
-    ctx1b.application_id = "app-1";
-    ctx1b.session_id = "session-2";
-    ctx1b.view_id = "view-1b";
-    ctx1b.view_name = "Page1b";
-    EXPECT_TRUE(_profiler->UpdateRumContext(&ctx1b));
+    RumSessionContext sessionCtx1b = {};
+    sessionCtx1b.application_id = "app-1";
+    sessionCtx1b.session_id = "session-2";
+    EXPECT_TRUE(_profiler->SetRumSession(&sessionCtx1b));
+
+    RumViewValues viewVals1b = {};
+    viewVals1b.view_id = "view-1b";
+    viewVals1b.view_name = "Page1b";
+    _profiler->SetRumView(&viewVals1b);
 
     RumViewContext viewCtx;
     EXPECT_TRUE(_profiler->GetCurrentViewContext(viewCtx));
@@ -148,20 +158,21 @@ TEST_F(ProfilerRumContextTest, AppIdSetOnce) {
 }
 
 TEST_F(ProfilerRumContextTest, DifferentAppIdRejected) {
-    RumContextValues ctx1 = {};
-    ctx1.application_id = "app-1";
-    ctx1.session_id = "session-1";
-    ctx1.view_id = "view-1";
-    ctx1.view_name = "Page1";
-    EXPECT_TRUE(_profiler->UpdateRumContext(&ctx1));
+    RumSessionContext sessionCtx1 = {};
+    sessionCtx1.application_id = "app-1";
+    sessionCtx1.session_id = "session-1";
+    EXPECT_TRUE(_profiler->SetRumSession(&sessionCtx1));
+
+    RumViewValues viewVals1 = {};
+    viewVals1.view_id = "view-1";
+    viewVals1.view_name = "Page1";
+    _profiler->SetRumView(&viewVals1);
 
     // Different application_id should be rejected (view unchanged)
-    RumContextValues ctx2 = {};
-    ctx2.application_id = "app-2";
-    ctx2.session_id = "session-1";
-    ctx2.view_id = "view-2";
-    ctx2.view_name = "Page2";
-    EXPECT_FALSE(_profiler->UpdateRumContext(&ctx2));
+    RumSessionContext sessionCtx2 = {};
+    sessionCtx2.application_id = "app-2";
+    sessionCtx2.session_id = "session-1";
+    EXPECT_FALSE(_profiler->SetRumSession(&sessionCtx2));
 
     RumViewContext viewCtx;
     EXPECT_TRUE(_profiler->GetCurrentViewContext(viewCtx));
@@ -176,50 +187,55 @@ TEST_F(ProfilerRumContextTest, NoActiveViewByDefault) {
 
 TEST_F(ProfilerRumContextTest, ViewTransitionPattern) {
     // Simulates the real callback pattern: set view -> clear -> set new view
-    RumContextValues ctx = {};
-    ctx.application_id = "app-1";
-    ctx.session_id = "session-1";
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-1";
+    sessionCtx.session_id = "session-1";
+    _profiler->SetRumSession(&sessionCtx);
 
     // Set first view
-    ctx.view_id = "view-1";
-    ctx.view_name = "HomePage";
-    _profiler->UpdateRumContext(&ctx);
+    RumViewValues viewVals = {};
+    viewVals.view_id = "view-1";
+    viewVals.view_name = "HomePage";
+    _profiler->SetRumView(&viewVals);
 
     RumViewContext viewCtx;
     EXPECT_TRUE(_profiler->GetCurrentViewContext(viewCtx));
     EXPECT_EQ(viewCtx.view_id, "view-1");
 
     // Clear view (between views)
-    ctx.view_id = nullptr;
-    ctx.view_name = nullptr;
-    _profiler->UpdateRumContext(&ctx);
+    viewVals.view_id = nullptr;
+    viewVals.view_name = nullptr;
+    _profiler->SetRumView(&viewVals);
     EXPECT_FALSE(_profiler->GetCurrentViewContext(viewCtx));
 
     // Set second view
-    ctx.view_id = "view-2";
-    ctx.view_name = "SettingsPage";
-    _profiler->UpdateRumContext(&ctx);
+    viewVals.view_id = "view-2";
+    viewVals.view_name = "SettingsPage";
+    _profiler->SetRumView(&viewVals);
     EXPECT_TRUE(_profiler->GetCurrentViewContext(viewCtx));
     EXPECT_EQ(viewCtx.view_id, "view-2");
     EXPECT_EQ(viewCtx.view_name, "SettingsPage");
 }
 
 TEST_F(ProfilerRumContextTest, ViewContextCopyIsIndependent) {
-    RumContextValues ctx = {};
-    ctx.application_id = "app-1";
-    ctx.session_id = "session-1";
-    ctx.view_id = "view-1";
-    ctx.view_name = "HomePage";
-    _profiler->UpdateRumContext(&ctx);
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-1";
+    sessionCtx.session_id = "session-1";
+    _profiler->SetRumSession(&sessionCtx);
+
+    RumViewValues viewVals = {};
+    viewVals.view_id = "view-1";
+    viewVals.view_name = "HomePage";
+    _profiler->SetRumView(&viewVals);
 
     // Get a copy of the view context
     RumViewContext snapshot;
     EXPECT_TRUE(_profiler->GetCurrentViewContext(snapshot));
 
     // Update to a new view
-    ctx.view_id = "view-2";
-    ctx.view_name = "SettingsPage";
-    _profiler->UpdateRumContext(&ctx);
+    viewVals.view_id = "view-2";
+    viewVals.view_name = "SettingsPage";
+    _profiler->SetRumView(&viewVals);
 
     // The snapshot should still hold the old values
     EXPECT_EQ(snapshot.view_id, "view-1");
@@ -390,22 +406,25 @@ TEST_F(ProfilerRumContextTest, ConsumeViewRecordsEmptyByDefault) {
 }
 
 TEST_F(ProfilerRumContextTest, SetAndClearViewProducesOneRecord) {
-    RumContextValues ctx = {};
-    ctx.application_id = "app-1";
-    ctx.session_id = "session-1";
-    ctx.view_id = "view-1";
-    ctx.view_name = "HomePage";
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-1";
+    sessionCtx.session_id = "session-1";
+    _profiler->SetRumSession(&sessionCtx);
+
+    RumViewValues viewVals = {};
+    viewVals.view_id = "view-1";
+    viewVals.view_name = "HomePage";
 
     auto beforeMs = std::chrono::duration_cast<std::chrono::milliseconds>(
         std::chrono::system_clock::now().time_since_epoch()).count();
 
-    _profiler->UpdateRumContext(&ctx);
+    _profiler->SetRumView(&viewVals);
     ::Sleep(50);
 
     // Clear the view
-    ctx.view_id = "";
-    ctx.view_name = "";
-    _profiler->UpdateRumContext(&ctx);
+    viewVals.view_id = "";
+    viewVals.view_name = "";
+    _profiler->SetRumView(&viewVals);
 
     auto afterMs = std::chrono::duration_cast<std::chrono::milliseconds>(
         std::chrono::system_clock::now().time_since_epoch()).count();
@@ -422,16 +441,19 @@ TEST_F(ProfilerRumContextTest, SetAndClearViewProducesOneRecord) {
 }
 
 TEST_F(ProfilerRumContextTest, ConsumeSwapsBufferSecondCallEmpty) {
-    RumContextValues ctx = {};
-    ctx.application_id = "app-1";
-    ctx.session_id = "session-1";
-    ctx.view_id = "view-1";
-    ctx.view_name = "Page1";
-    _profiler->UpdateRumContext(&ctx);
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-1";
+    sessionCtx.session_id = "session-1";
+    _profiler->SetRumSession(&sessionCtx);
 
-    ctx.view_id = "";
-    ctx.view_name = "";
-    _profiler->UpdateRumContext(&ctx);
+    RumViewValues viewVals = {};
+    viewVals.view_id = "view-1";
+    viewVals.view_name = "Page1";
+    _profiler->SetRumView(&viewVals);
+
+    viewVals.view_id = "";
+    viewVals.view_name = "";
+    _profiler->SetRumView(&viewVals);
 
     std::vector<RumViewRecord> records;
     _profiler->ConsumeViewRecords(records);
@@ -443,12 +465,15 @@ TEST_F(ProfilerRumContextTest, ConsumeSwapsBufferSecondCallEmpty) {
 }
 
 TEST_F(ProfilerRumContextTest, PendingViewProducesNoRecord) {
-    RumContextValues ctx = {};
-    ctx.application_id = "app-1";
-    ctx.session_id = "session-1";
-    ctx.view_id = "view-1";
-    ctx.view_name = "Page1";
-    _profiler->UpdateRumContext(&ctx);
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-1";
+    sessionCtx.session_id = "session-1";
+    _profiler->SetRumSession(&sessionCtx);
+
+    RumViewValues viewVals = {};
+    viewVals.view_id = "view-1";
+    viewVals.view_name = "Page1";
+    _profiler->SetRumView(&viewVals);
 
     std::vector<RumViewRecord> records;
     _profiler->ConsumeViewRecords(records);
@@ -456,12 +481,15 @@ TEST_F(ProfilerRumContextTest, PendingViewProducesNoRecord) {
 }
 
 TEST_F(ProfilerRumContextTest, ClearWithoutSetProducesNoRecord) {
-    RumContextValues ctx = {};
-    ctx.application_id = "app-1";
-    ctx.session_id = "session-1";
-    ctx.view_id = "";
-    ctx.view_name = "";
-    _profiler->UpdateRumContext(&ctx);
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-1";
+    sessionCtx.session_id = "session-1";
+    _profiler->SetRumSession(&sessionCtx);
+
+    RumViewValues viewVals = {};
+    viewVals.view_id = "";
+    viewVals.view_name = "";
+    _profiler->SetRumView(&viewVals);
 
     std::vector<RumViewRecord> records;
     _profiler->ConsumeViewRecords(records);
@@ -469,31 +497,34 @@ TEST_F(ProfilerRumContextTest, ClearWithoutSetProducesNoRecord) {
 }
 
 TEST_F(ProfilerRumContextTest, ViewTransitionsProduceMultipleRecords) {
-    RumContextValues ctx = {};
-    ctx.application_id = "app-1";
-    ctx.session_id = "session-1";
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-1";
+    sessionCtx.session_id = "session-1";
+    _profiler->SetRumSession(&sessionCtx);
+
+    RumViewValues viewVals = {};
 
     // View 1
-    ctx.view_id = "view-1";
-    ctx.view_name = "Page1";
-    _profiler->UpdateRumContext(&ctx);
+    viewVals.view_id = "view-1";
+    viewVals.view_name = "Page1";
+    _profiler->SetRumView(&viewVals);
     ::Sleep(20);
 
     // Clear view 1
-    ctx.view_id = "";
-    ctx.view_name = "";
-    _profiler->UpdateRumContext(&ctx);
+    viewVals.view_id = "";
+    viewVals.view_name = "";
+    _profiler->SetRumView(&viewVals);
 
     // View 2
-    ctx.view_id = "view-2";
-    ctx.view_name = "Page2";
-    _profiler->UpdateRumContext(&ctx);
+    viewVals.view_id = "view-2";
+    viewVals.view_name = "Page2";
+    _profiler->SetRumView(&viewVals);
     ::Sleep(20);
 
     // Clear view 2
-    ctx.view_id = "";
-    ctx.view_name = "";
-    _profiler->UpdateRumContext(&ctx);
+    viewVals.view_id = "";
+    viewVals.view_name = "";
+    _profiler->SetRumView(&viewVals);
 
     std::vector<RumViewRecord> records;
     _profiler->ConsumeViewRecords(records);
@@ -634,36 +665,30 @@ TEST(RumSessionRecordTests, ValueInitialization) {
 // ---------------------------------------------------------------------------
 
 TEST_F(ProfilerRumContextTest, SessionIdCanChange) {
-    RumContextValues ctx = {};
-    ctx.application_id = "app-1";
-    ctx.session_id = "S1";
-    ctx.view_id = "view-1";
-    ctx.view_name = "Page1";
-    EXPECT_TRUE(_profiler->UpdateRumContext(&ctx));
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-1";
+    sessionCtx.session_id = "S1";
+    EXPECT_TRUE(_profiler->SetRumSession(&sessionCtx));
     EXPECT_EQ(_profiler->GetCurrentSessionId(), "S1");
 
-    ctx.session_id = "S2";
-    ctx.view_id = "view-2";
-    ctx.view_name = "Page2";
-    EXPECT_TRUE(_profiler->UpdateRumContext(&ctx));
+    sessionCtx.session_id = "S2";
+    EXPECT_TRUE(_profiler->SetRumSession(&sessionCtx));
     EXPECT_EQ(_profiler->GetCurrentSessionId(), "S2");
 }
 
 TEST_F(ProfilerRumContextTest, SessionIdChangeCompletesRecord) {
-    RumContextValues ctx = {};
-    ctx.application_id = "app-1";
-    ctx.session_id = "S1";
-    ctx.view_id = "view-1";
-    ctx.view_name = "Page1";
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-1";
+    sessionCtx.session_id = "S1";
 
     auto beforeMs = std::chrono::duration_cast<std::chrono::milliseconds>(
         std::chrono::system_clock::now().time_since_epoch()).count();
 
-    _profiler->UpdateRumContext(&ctx);
+    _profiler->SetRumSession(&sessionCtx);
     ::Sleep(50);
 
-    ctx.session_id = "S2";
-    _profiler->UpdateRumContext(&ctx);
+    sessionCtx.session_id = "S2";
+    _profiler->SetRumSession(&sessionCtx);
 
     std::vector<RumSessionRecord> records;
     _profiler->ConsumeSessionRecords(records);
@@ -674,21 +699,19 @@ TEST_F(ProfilerRumContextTest, SessionIdChangeCompletesRecord) {
 }
 
 TEST_F(ProfilerRumContextTest, MultipleSessionTransitions) {
-    RumContextValues ctx = {};
-    ctx.application_id = "app-1";
-    ctx.view_id = "view-1";
-    ctx.view_name = "Page1";
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-1";
 
-    ctx.session_id = "S1";
-    _profiler->UpdateRumContext(&ctx);
+    sessionCtx.session_id = "S1";
+    _profiler->SetRumSession(&sessionCtx);
     ::Sleep(20);
 
-    ctx.session_id = "S2";
-    _profiler->UpdateRumContext(&ctx);
+    sessionCtx.session_id = "S2";
+    _profiler->SetRumSession(&sessionCtx);
     ::Sleep(20);
 
-    ctx.session_id = "S3";
-    _profiler->UpdateRumContext(&ctx);
+    sessionCtx.session_id = "S3";
+    _profiler->SetRumSession(&sessionCtx);
 
     std::vector<RumSessionRecord> records;
     _profiler->ConsumeSessionRecords(records);
@@ -707,15 +730,13 @@ TEST_F(ProfilerRumContextTest, ConsumeSessionRecordsEmptyByDefault) {
 }
 
 TEST_F(ProfilerRumContextTest, ConsumeSessionRecordsSwapsBuffer) {
-    RumContextValues ctx = {};
-    ctx.application_id = "app-1";
-    ctx.session_id = "S1";
-    ctx.view_id = "view-1";
-    ctx.view_name = "Page1";
-    _profiler->UpdateRumContext(&ctx);
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-1";
+    sessionCtx.session_id = "S1";
+    _profiler->SetRumSession(&sessionCtx);
 
-    ctx.session_id = "S2";
-    _profiler->UpdateRumContext(&ctx);
+    sessionCtx.session_id = "S2";
+    _profiler->SetRumSession(&sessionCtx);
 
     std::vector<RumSessionRecord> records;
     _profiler->ConsumeSessionRecords(records);
@@ -727,16 +748,13 @@ TEST_F(ProfilerRumContextTest, ConsumeSessionRecordsSwapsBuffer) {
 }
 
 TEST_F(ProfilerRumContextTest, SameSessionIdDoesNotCreateRecord) {
-    RumContextValues ctx = {};
-    ctx.application_id = "app-1";
-    ctx.session_id = "S1";
-    ctx.view_id = "view-1";
-    ctx.view_name = "Page1";
-    _profiler->UpdateRumContext(&ctx);
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-1";
+    sessionCtx.session_id = "S1";
+    _profiler->SetRumSession(&sessionCtx);
 
-    ctx.view_id = "view-2";
-    ctx.view_name = "Page2";
-    _profiler->UpdateRumContext(&ctx);
+    // Calling SetRumSession again with the same session_id should not create a record
+    _profiler->SetRumSession(&sessionCtx);
 
     std::vector<RumSessionRecord> records;
     _profiler->ConsumeSessionRecords(records);

--- a/src/dd-win-prof/Configuration.cpp
+++ b/src/dd-win-prof/Configuration.cpp
@@ -587,7 +587,7 @@ T Configuration::GetEnvironmentValue(char const* name, T const& defaultValue)
     return result;
 }
 
-bool InitializeConfiguration(Configuration* pConfig, ProfilerConfig* pSettings)
+bool InitializeConfiguration(Configuration* pConfig, const ProfilerConfig* pSettings)
 {
     // if noEnvVars is set, we ignore all environment variables and use only the values provided in the ProfilerConfig struct (or defaults if not set in the struct)
     if (pSettings->noEnvVars)

--- a/src/dd-win-prof/Profiler.cpp
+++ b/src/dd-win-prof/Profiler.cpp
@@ -154,7 +154,7 @@ void Profiler::RemoveCurrentThread()
     _pThreadList->RemoveThread(tid);
 }
 
-bool Profiler::UpdateRumContext(const RumContextValues* pContext)
+bool Profiler::SetRumSession(const RumSessionContext* pContext)
 {
     if (pContext == nullptr)
     {
@@ -186,11 +186,10 @@ bool Profiler::UpdateRumContext(const RumContextValues* pContext)
         }
     }
 
-    // Session + view context: update under exclusive/writer lock
+    // Session tracking: complete previous session on change, start new one
     {
         std::unique_lock lock(_rumContextMutex);
 
-        // Session tracking: complete previous session on change, start new one
         bool hasSessionId = pContext->session_id != nullptr && pContext->session_id[0] != '\0';
         if (hasSessionId && _currentSessionId != pContext->session_id)
         {
@@ -210,40 +209,104 @@ bool Profiler::UpdateRumContext(const RumContextValues* pContext)
                 std::chrono::system_clock::now().time_since_epoch()).count();
             _hasPendingSession = true;
         }
-
-        // View tracking
-        if (pContext->view_id != nullptr && pContext->view_id[0] != '\0')
-        {
-            _currentRumView.view_id = pContext->view_id;
-            _currentRumView.view_name = (pContext->view_name != nullptr) ? pContext->view_name : "";
-            _hasActiveView = true;
-
-            _pendingViewStartMs = std::chrono::duration_cast<std::chrono::milliseconds>(
-                std::chrono::system_clock::now().time_since_epoch()).count();
-            _hasPendingView = true;
-        }
-        else
-        {
-            if (_hasPendingView)
-            {
-                auto nowMs = std::chrono::duration_cast<std::chrono::milliseconds>(
-                    std::chrono::system_clock::now().time_since_epoch()).count();
-                _completedViewRecords.push_back({
-                    _pendingViewStartMs,
-                    nowMs - _pendingViewStartMs,
-                    std::move(_currentRumView.view_id),
-                    std::move(_currentRumView.view_name)
-                });
-                _hasPendingView = false;
-            }
-
-            _currentRumView.view_id.clear();
-            _currentRumView.view_name.clear();
-            _hasActiveView = false;
-        }
     }
 
     return true;
+}
+
+void Profiler::SetRumView(const RumViewValues* pContext)
+{
+    std::unique_lock lock(_rumContextMutex);
+
+    if (pContext != nullptr && pContext->view_id != nullptr && pContext->view_id[0] != '\0')
+    {
+        // Complete the previous view if one was pending
+        if (_hasPendingView)
+        {
+            auto nowMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::system_clock::now().time_since_epoch()).count();
+            _completedViewRecords.push_back({
+                _pendingViewStartMs,
+                nowMs - _pendingViewStartMs,
+                std::move(_currentRumView.view_id),
+                std::move(_currentRumView.view_name)
+            });
+        }
+
+        _currentRumView.view_id = pContext->view_id;
+        _currentRumView.view_name = (pContext->view_name != nullptr) ? pContext->view_name : "";
+        _hasActiveView = true;
+
+        _pendingViewStartMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+        _hasPendingView = true;
+    }
+    else
+    {
+        // Clear the view (nullptr or empty view_id signals "between views")
+        if (_hasPendingView)
+        {
+            auto nowMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::system_clock::now().time_since_epoch()).count();
+            _completedViewRecords.push_back({
+                _pendingViewStartMs,
+                nowMs - _pendingViewStartMs,
+                std::move(_currentRumView.view_id),
+                std::move(_currentRumView.view_name)
+            });
+            _hasPendingView = false;
+        }
+
+        _currentRumView.view_id.clear();
+        _currentRumView.view_name.clear();
+        _hasActiveView = false;
+    }
+}
+
+void Profiler::ClearRumContext()
+{
+    // Clear session state
+    {
+        std::unique_lock lock(_rumContextMutex);
+
+        // Complete the pending session
+        if (_hasPendingSession)
+        {
+            auto nowMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::system_clock::now().time_since_epoch()).count();
+            _completedSessionRecords.push_back({
+                _sessionStartMs,
+                nowMs - _sessionStartMs,
+                std::move(_currentSessionId)
+            });
+            _hasPendingSession = false;
+        }
+        _currentSessionId.clear();
+
+        // Complete the pending view
+        if (_hasPendingView)
+        {
+            auto nowMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::system_clock::now().time_since_epoch()).count();
+            _completedViewRecords.push_back({
+                _pendingViewStartMs,
+                nowMs - _pendingViewStartMs,
+                std::move(_currentRumView.view_id),
+                std::move(_currentRumView.view_name)
+            });
+            _hasPendingView = false;
+        }
+        _currentRumView.view_id.clear();
+        _currentRumView.view_name.clear();
+        _hasActiveView = false;
+    }
+
+    // Clear the application ID
+    {
+        std::lock_guard lock(_rumAppMutex);
+        _rumAppIdSet = false;
+        _rumApplicationId.clear();
+    }
 }
 
 bool Profiler::GetCurrentViewContext(RumViewContext& context) const

--- a/src/dd-win-prof/Profiler.h
+++ b/src/dd-win-prof/Profiler.h
@@ -32,7 +32,9 @@ public :
     bool IsAutoStartEnabled() const { return _pConfiguration->IsProfilerAutoStartEnabled(); }
 
     // RUM context management (called from the C API, thread-safe)
-    bool UpdateRumContext(const RumContextValues* pContext);
+    bool SetRumSession(const RumSessionContext* pContext);
+    void SetRumView(const RumViewValues* pContext);
+    void ClearRumContext();
 
     // IRumViewContextProvider implementation
     bool GetCurrentViewContext(RumViewContext& context) const override;

--- a/src/dd-win-prof/dd-win-prof-internal.h
+++ b/src/dd-win-prof/dd-win-prof-internal.h
@@ -10,4 +10,4 @@
 // When pSettings->noEnvVars is true, resets to defaults first so that
 // only the explicit struct fields take effect.
 // Returns false if mandatory fields are missing (url, apiKey when noEnvVars).
-bool InitializeConfiguration(Configuration* pConfig, ProfilerConfig* pSettings);
+bool InitializeConfiguration(Configuration* pConfig, const ProfilerConfig* pSettings);

--- a/src/dd-win-prof/dd-win-prof.cpp
+++ b/src/dd-win-prof/dd-win-prof.cpp
@@ -8,7 +8,7 @@
 
 extern "C" {
 
-DD_WIN_PROF_API bool SetupProfiler(ProfilerConfig* pSettings)
+DD_WIN_PROF_API bool SetupProfiler(const ProfilerConfig* pSettings)
 {
     if (pSettings == nullptr)
     {

--- a/src/dd-win-prof/dd-win-prof.cpp
+++ b/src/dd-win-prof/dd-win-prof.cpp
@@ -74,14 +74,34 @@ DD_WIN_PROF_API void StopProfiler()
     profiler->StopProfiling();
 }
 
-DD_WIN_PROF_API bool UpdateRumContext(const RumContextValues* pContext)
+DD_WIN_PROF_API bool SetRumSession(const RumSessionContext* pContext)
 {
     auto profiler = Profiler::GetInstance();
     if (profiler == nullptr)
     {
         return false;
     }
-    return profiler->UpdateRumContext(pContext);
+    return profiler->SetRumSession(pContext);
+}
+
+DD_WIN_PROF_API void SetRumView(const RumViewValues* pContext)
+{
+    auto profiler = Profiler::GetInstance();
+    if (profiler == nullptr)
+    {
+        return;
+    }
+    profiler->SetRumView(pContext);
+}
+
+DD_WIN_PROF_API void ClearRumContext()
+{
+    auto profiler = Profiler::GetInstance();
+    if (profiler == nullptr)
+    {
+        return;
+    }
+    profiler->ClearRumContext();
 }
 
 }

--- a/src/dd-win-prof/dd-win-prof.h
+++ b/src/dd-win-prof/dd-win-prof.h
@@ -46,33 +46,47 @@ typedef struct _ProfilerConfig
 } ProfilerConfig;
 
 
-// RUM (Real User Monitoring) context values.
-// Passed by dd-sdk-cpp to correlate profiling data with user sessions/views.
-typedef struct _RumContextValues
+// RUM (Real User Monitoring) context — split into stable vs volatile APIs.
+//
+// Stable context: application_id and session_id change infrequently (session start,
+// session rotation). These are used for profile-level pprof tags. Can allocate.
+typedef struct _RumSessionContext
 {
     const char* application_id;  // UUID string, set once per process lifetime
-    const char* session_id;      // UUID string, can change on session rotation
-    const char* view_id;         // nullptr or "" to clear current view
-    const char* view_name;       // human-readable name, e.g. "HomePage"
-} RumContextValues;
+    const char* session_id;      // UUID string, changes on session rotation
+} RumSessionContext;
+
+// Volatile context: view_id and view_name change on every navigation.
+// HOT PATH for per-sample pprof labels (rum.view_id, trace endpoint).
+typedef struct _RumViewValues
+{
+    const char* view_id;    // UUID string; nullptr or "" to clear current view
+    const char* view_name;  // human-readable name, e.g. "HomePage"
+} RumViewValues;
 
 extern "C" {
     DD_WIN_PROF_API bool SetupProfiler(ProfilerConfig* pSettings);
+
     // Start profiling manually (returns false if already started or explicitly disabled)
     DD_WIN_PROF_API bool StartProfiler();
 
     // Stop profiling manually (safe to call even if not started)
     DD_WIN_PROF_API void StopProfiler();
 
-    // Update RUM context. Safe to call from any thread.
-    // On first call with non-empty application_id, stores it as a profile-level tag
-    // (subsequent calls with a different application_id are rejected).
-    // On every call with non-empty session_id, updates the current session. Session
-    // transitions are tracked with timestamps; the profile-level rum.session_id tag
-    // lists all session_ids since the last export.
-    // On every call, updates the view-level context (view_id/view_name).
+    // Set stable RUM session context. Safe to call from any thread.
+    // application_id: write-once per process. First non-empty value is stored as a
+    //   profile-level tag; subsequent calls with a different value are rejected (returns false).
+    // session_id: updated on every call. Session transitions are tracked with timestamps;
+    //   the profile-level rum.session_id tag lists all session_ids since the last export.
+    DD_WIN_PROF_API bool SetRumSession(const RumSessionContext* pContext);
+
+    // Set volatile RUM view context. Safe to call from any thread.
+    // Updates per-sample pprof labels: rum.view_id and trace endpoint (view_name).
     // Pass nullptr/empty view_id to clear the current view (signals "between views").
-    DD_WIN_PROF_API bool UpdateRumContext(const RumContextValues* pContext);
+    DD_WIN_PROF_API void SetRumView(const RumViewValues* pContext);
+
+    // Clear all RUM context (both session and view). Call on session end.
+    DD_WIN_PROF_API void ClearRumContext();
 
     // Environment Variables (independent controls):
     // DD_PROFILING_ENABLED: Controls whether profiler CAN be started

--- a/src/dd-win-prof/dd-win-prof.h
+++ b/src/dd-win-prof/dd-win-prof.h
@@ -65,7 +65,7 @@ typedef struct _RumViewValues
 } RumViewValues;
 
 extern "C" {
-    DD_WIN_PROF_API bool SetupProfiler(ProfilerConfig* pSettings);
+    DD_WIN_PROF_API bool SetupProfiler(const ProfilerConfig* pSettings);
 
     // Start profiling manually (returns false if already started or explicitly disabled)
     DD_WIN_PROF_API bool StartProfiler();


### PR DESCRIPTION
## Description
<!-- Brief description of what this PR does -->
Replace the single UpdateRumContext(RumContextValues*) with three focused APIs:

- SetRumSession(RumSessionContext*): stable context (application_id, session_id). Called once at session start or on rotation. Can allocate, not performance-critical.

- SetRumView(RumViewValues*): volatile context (view_id, view_name). Called on every view navigation. Hot path for per-sample pprof labels.

- ClearRumContext(): clears both session and view state on session end.

This split allows the SDK to call session and view updates independently, matching the natural lifecycle of RUM events and enabling lock-free optimizations on the view hot path in the future.

## Motivation
<!-- Why is this change needed? What problem does it solve? -->


## Testing
<!-- How was this change tested? -->
- [x] Built successfully on Windows
- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually tested

## Checklist
- [x] Code follows existing style
- [x] Documentation updated (if needed)
- [ ] No breaking changes (or clearly documented) 