### PR TITLE
Add wait and cpu duration vitals per view

### DIFF
--- a/src/Runner/CMakeLists.txt
+++ b/src/Runner/CMakeLists.txt
@@ -39,4 +39,5 @@ add_custom_command(
     VERBATIM
 )
 add_custom_target(Runner_runtime_deps DEPENDS "${_runner_runtime_deps_stamp}")
+add_dependencies(Runner_runtime_deps dd-win-prof)
 add_dependencies(Runner Runner_runtime_deps)

--- a/src/Runner/CMakeLists.txt
+++ b/src/Runner/CMakeLists.txt
@@ -13,12 +13,30 @@ set_property(TARGET Runner PROPERTY INTERPROCEDURAL_OPTIMIZATION_RELEASE ON)
 
 # Copy the full contents of src/reference (dd-win-prof.dll, libdatadog DLLs, etc.)
 # to the Runner output directory so that Runner.exe can be launched in-place.
-# The vcxproj restricts this to Release; we apply it unconditionally here because
-# dd-win-prof's post-build step populates src/reference in all configurations.
-add_custom_command(TARGET Runner POST_BUILD
+#
+# We use an OUTPUT/DEPENDS custom command (rather than POST_BUILD on Runner)
+# so that the copy step is driven by the dd-win-prof DLL's timestamp, not by
+# whether Runner.exe itself was rebuilt. Without this, changing only
+# dd-win-prof's implementation leaves Runner's import .lib unchanged, the
+# Runner target looks "up-to-date" to MSBuild, and its POST_BUILD step is
+# skipped -- so the Runner output directory keeps a stale DLL.
+#
+# A per-config stamp file acts as the command's OUTPUT (target-dependent
+# generator expressions aren't allowed in OUTPUT, so we can't use the copied
+# DLL's path directly). The stamp is touched after the copy and, being newer
+# than the source DLL only while the copy is fresh, drives incremental
+# rebuilds correctly. Works identically for Visual Studio, Ninja and Makefile
+# generators.
+set(_runner_runtime_deps_stamp "${CMAKE_CURRENT_BINARY_DIR}/runtime_deps_$<CONFIG>.stamp")
+add_custom_command(
+    OUTPUT "${_runner_runtime_deps_stamp}"
     COMMAND ${CMAKE_COMMAND} -E copy_directory
         "${WINDOWSPROFILER_ROOT_DIR}/src/reference"
         "$<TARGET_FILE_DIR:Runner>"
-    VERBATIM
+    COMMAND ${CMAKE_COMMAND} -E touch "${_runner_runtime_deps_stamp}"
+    DEPENDS $<TARGET_FILE:dd-win-prof>
     COMMENT "Copying reference binaries to Runner output directory"
+    VERBATIM
 )
+add_custom_target(Runner_runtime_deps DEPENDS "${_runner_runtime_deps_stamp}")
+add_dependencies(Runner Runner_runtime_deps)

--- a/src/Runner/Runner.cpp
+++ b/src/Runner/Runner.cpp
@@ -5,6 +5,7 @@
 //
 
 #include <iostream>
+#include <random>
 #include <string>
 #include <Windows.h>
 
@@ -337,32 +338,56 @@ void RunWaitingThreads()
 
 
 // Scenario 5: RUM context view transitions
-void SetView(const std::string& appId, const std::string& sessionId,
-             const char* viewId, const char* viewName)
+
+static std::string GenerateViewId()
 {
+    static std::mt19937 rng(std::random_device{}());
+    std::uniform_int_distribution<uint32_t> dist(0, 0xFFFFFFFF);
+
+    char buf[37]; // 8-4-4-4-12 + NUL
+    auto r = [&]() { return dist(rng); };
+    std::snprintf(buf, sizeof(buf),
+        "%08x-%04x-%04x-%04x-%04x%08x",
+        r(),
+        r() & 0xFFFF,
+        (r() & 0x0FFF) | 0x4000,   // version 4
+        (r() & 0x3FFF) | 0x8000,   // variant 1
+        r() & 0xFFFF, r());
+    return buf;
+}
+
+void SetView(const std::string& appId, const std::string& sessionId,
+             const char* viewName)
+{
+    std::string viewId = GenerateViewId();
     RumContextValues ctx = {};
     ctx.application_id = appId.c_str();
     ctx.session_id = sessionId.c_str();
-    ctx.view_id = viewId;
+    ctx.view_id = viewId.c_str();
     ctx.view_name = viewName;
     UpdateRumContext(&ctx);
 }
 
 void ClearView(const std::string& appId, const std::string& sessionId)
 {
-    SetView(appId, sessionId, nullptr, nullptr);
+    RumContextValues ctx = {};
+    ctx.application_id = appId.c_str();
+    ctx.session_id = sessionId.c_str();
+    ctx.view_id = nullptr;
+    ctx.view_name = nullptr;
+    UpdateRumContext(&ctx);
 }
 
 void RunRumScenario(const std::string& appId, const std::string& sessionId)
 {
     static const std::string sessionId2 = "99999999-2222-3333-4444-555555555555";
 
-    SetView(appId, sessionId, "11111111-1111-1111-1111-111111111111", "HomePage");
+    SetView(appId, sessionId, "HomePage");
     std::cout << "View 1: HomePage, session S1 (spinning 2s)..." << std::endl;
     Spin(2000);
 
     ClearView(appId, sessionId);
-    SetView(appId, sessionId, "22222222-2222-2222-2222-222222222222", "SettingsPage");
+    SetView(appId, sessionId, "SettingsPage");
     std::cout << "View 2: SettingsPage, session S1 (spinning 2s)..." << std::endl;
     Spin(2000);
 
@@ -371,7 +396,7 @@ void RunRumScenario(const std::string& appId, const std::string& sessionId)
     Spin(1000);
 
     // Session rotation: switch from S1 to S2
-    SetView(appId, sessionId2, "33333333-3333-3333-3333-333333333333", "ProfilePage");
+    SetView(appId, sessionId2, "ProfilePage");
     std::cout << "View 3: ProfilePage, session S2 (spinning 2s)..." << std::endl;
     Spin(2000);
 

--- a/src/Tests/RumContextTests.cpp
+++ b/src/Tests/RumContextTests.cpp
@@ -760,8 +760,10 @@ TEST_F(ProfilerRumContextTest, VitalsAccumulateDuringActiveView) {
     ctx.view_name = "HomePage";
     _profiler->UpdateRumContext(&ctx);
 
-    _profiler->AccumulateViewVitals(1000, 2000);
-    _profiler->AccumulateViewVitals(500, 3000);
+    EXPECT_TRUE(_profiler->AccumulateViewVitals(ViewVitalKind::WaitTime, 1000));
+    EXPECT_TRUE(_profiler->AccumulateViewVitals(ViewVitalKind::CpuTime, 2000));
+    EXPECT_TRUE(_profiler->AccumulateViewVitals(ViewVitalKind::WaitTime, 500));
+    EXPECT_TRUE(_profiler->AccumulateViewVitals(ViewVitalKind::CpuTime, 3000));
 
     // End the view
     ctx.view_id = "";
@@ -784,7 +786,8 @@ TEST_F(ProfilerRumContextTest, VitalsResetOnViewEnd) {
     ctx.view_id = "view-1";
     ctx.view_name = "Page1";
     _profiler->UpdateRumContext(&ctx);
-    _profiler->AccumulateViewVitals(100, 200);
+    _profiler->AccumulateViewVitals(ViewVitalKind::WaitTime, 100);
+    _profiler->AccumulateViewVitals(ViewVitalKind::CpuTime, 200);
 
     ctx.view_id = "";
     ctx.view_name = "";
@@ -817,7 +820,8 @@ TEST_F(ProfilerRumContextTest, VitalsResetOnNewViewStart) {
     ctx.view_id = "view-1";
     ctx.view_name = "Page1";
     _profiler->UpdateRumContext(&ctx);
-    _profiler->AccumulateViewVitals(1000, 2000);
+    _profiler->AccumulateViewVitals(ViewVitalKind::WaitTime, 1000);
+    _profiler->AccumulateViewVitals(ViewVitalKind::CpuTime, 2000);
 
     // Switch directly to a new view (without clearing)
     ctx.view_id = "view-2";
@@ -825,7 +829,8 @@ TEST_F(ProfilerRumContextTest, VitalsResetOnNewViewStart) {
     _profiler->UpdateRumContext(&ctx);
 
     // Accumulate for the second view
-    _profiler->AccumulateViewVitals(300, 400);
+    _profiler->AccumulateViewVitals(ViewVitalKind::WaitTime, 300);
+    _profiler->AccumulateViewVitals(ViewVitalKind::CpuTime, 400);
 
     ctx.view_id = "";
     ctx.view_name = "";
@@ -837,6 +842,29 @@ TEST_F(ProfilerRumContextTest, VitalsResetOnNewViewStart) {
     EXPECT_EQ(records[0].view_id, "view-2");
     EXPECT_EQ(records[0].wait_time_ns, 300);
     EXPECT_EQ(records[0].cpu_time_ns, 400);
+}
+
+TEST_F(ProfilerRumContextTest, VitalsRejectOutOfRangeKind) {
+    RumContextValues ctx = {};
+    ctx.application_id = "app-1";
+    ctx.session_id = "session-1";
+    ctx.view_id = "view-1";
+    ctx.view_name = "Page1";
+    _profiler->UpdateRumContext(&ctx);
+
+    EXPECT_FALSE(_profiler->AccumulateViewVitals(ViewVitalKind::Unknown, 100));
+    EXPECT_FALSE(_profiler->AccumulateViewVitals(static_cast<ViewVitalKind>(255), 100));
+
+    // End view and verify nothing was accumulated from the rejected calls
+    ctx.view_id = "";
+    ctx.view_name = "";
+    _profiler->UpdateRumContext(&ctx);
+
+    std::vector<RumViewRecord> records;
+    _profiler->ConsumeViewRecords(records);
+    ASSERT_EQ(records.size(), 1u);
+    EXPECT_EQ(records[0].cpu_time_ns, 0);
+    EXPECT_EQ(records[0].wait_time_ns, 0);
 }
 
 TEST_F(ProfilerRumContextTest, VitalsZeroWhenNoAccumulation) {
@@ -891,3 +919,8 @@ TEST(RumRecordJsonTests, MultipleViewsWithDifferentVitals) {
     EXPECT_NE(json.find("\"vitals\":{\"cpuTimeNs\":100,\"waitTimeNs\":200}"), std::string::npos);
     EXPECT_NE(json.find("\"vitals\":{\"cpuTimeNs\":400,\"waitTimeNs\":500}"), std::string::npos);
 }
+
+// Note: the RUM records JSON built by SerializeRumRecordsToJson is also the
+// payload passed to libdatadog through optional_internal_metadata_json. The
+// tests above (RumRecordJsonTests) therefore double-cover that payload's
+// shape; no dedicated internal-metadata suite is needed.

--- a/src/Tests/RumContextTests.cpp
+++ b/src/Tests/RumContextTests.cpp
@@ -385,7 +385,7 @@ TEST(RumViewRecordTests, DefaultConstruction) {
     EXPECT_EQ(record.duration_ms, 0);
     EXPECT_TRUE(record.view_id.empty());
     EXPECT_TRUE(record.view_name.empty());
-    for (size_t i = 0; i < ViewVitalKindCount; ++i)
+    for (size_t i = 0; i < MaxViewVitalKind; ++i)
         EXPECT_EQ(record.vitals_ns[i], 0);
 }
 
@@ -885,7 +885,7 @@ TEST_F(ProfilerRumContextTest, VitalsRejectOutOfRangeKind) {
     std::vector<RumViewRecord> records;
     _profiler->ConsumeViewRecords(records);
     ASSERT_EQ(records.size(), 1u);
-    for (size_t i = 0; i < ViewVitalKindCount; ++i)
+    for (size_t i = 0; i < MaxViewVitalKind; ++i)
         EXPECT_EQ(records[0].vitals_ns[i], 0);
 }
 
@@ -905,7 +905,7 @@ TEST_F(ProfilerRumContextTest, VitalsZeroWhenNoAccumulation) {
     std::vector<RumViewRecord> records;
     _profiler->ConsumeViewRecords(records);
     ASSERT_EQ(records.size(), 1u);
-    for (size_t i = 0; i < ViewVitalKindCount; ++i)
+    for (size_t i = 0; i < MaxViewVitalKind; ++i)
         EXPECT_EQ(records[0].vitals_ns[i], 0);
 }
 

--- a/src/Tests/RumContextTests.cpp
+++ b/src/Tests/RumContextTests.cpp
@@ -369,14 +369,18 @@ TEST(RumViewRecordTests, DefaultConstruction) {
     EXPECT_EQ(record.duration_ms, 0);
     EXPECT_TRUE(record.view_id.empty());
     EXPECT_TRUE(record.view_name.empty());
+    EXPECT_EQ(record.cpu_time_ns, 0);
+    EXPECT_EQ(record.wait_time_ns, 0);
 }
 
 TEST(RumViewRecordTests, ValueInitialization) {
-    RumViewRecord record{1773058873970, 2000, "view-abc", "HomePage"};
+    RumViewRecord record{1773058873970, 2000, "view-abc", "HomePage", 500000, 300000};
     EXPECT_EQ(record.timestamp_ms, 1773058873970);
     EXPECT_EQ(record.duration_ms, 2000);
     EXPECT_EQ(record.view_id, "view-abc");
     EXPECT_EQ(record.view_name, "HomePage");
+    EXPECT_EQ(record.cpu_time_ns, 500000);
+    EXPECT_EQ(record.wait_time_ns, 300000);
 }
 
 // ---------------------------------------------------------------------------
@@ -519,7 +523,7 @@ TEST(RumRecordJsonTests, EmptyBothProducesEmptyJson) {
 
 TEST(RumRecordJsonTests, ViewsOnlyJson) {
     std::vector<RumViewRecord> views = {
-        {1773058873970, 2000, "view-1", "HomePage"}
+        {1773058873970, 2000, "view-1", "HomePage", 0, 0}
     };
     std::vector<RumSessionRecord> sessions;
     auto json = ProfileExporter::SerializeRumRecordsToJson(views, sessions);
@@ -527,7 +531,8 @@ TEST(RumRecordJsonTests, ViewsOnlyJson) {
         "{\"views\":[{\"startClocks\":{\"relative\":0,\"timeStamp\":1773058873970}"
         ",\"duration\":2000"
         ",\"viewId\":\"view-1\""
-        ",\"viewName\":\"HomePage\"}]"
+        ",\"viewName\":\"HomePage\""
+        ",\"vitals\":{\"cpuTimeNs\":0,\"waitTimeNs\":0}}]"
         ",\"sessions\":[]}");
 }
 
@@ -741,4 +746,148 @@ TEST_F(ProfilerRumContextTest, SameSessionIdDoesNotCreateRecord) {
     std::vector<RumSessionRecord> records;
     _profiler->ConsumeSessionRecords(records);
     EXPECT_TRUE(records.empty());
+}
+
+// ---------------------------------------------------------------------------
+// View vitals accumulation tests
+// ---------------------------------------------------------------------------
+
+TEST_F(ProfilerRumContextTest, VitalsAccumulateDuringActiveView) {
+    RumContextValues ctx = {};
+    ctx.application_id = "app-1";
+    ctx.session_id = "session-1";
+    ctx.view_id = "view-1";
+    ctx.view_name = "HomePage";
+    _profiler->UpdateRumContext(&ctx);
+
+    _profiler->AccumulateViewVitals(1000, 2000);
+    _profiler->AccumulateViewVitals(500, 3000);
+
+    // End the view
+    ctx.view_id = "";
+    ctx.view_name = "";
+    _profiler->UpdateRumContext(&ctx);
+
+    std::vector<RumViewRecord> records;
+    _profiler->ConsumeViewRecords(records);
+    ASSERT_EQ(records.size(), 1u);
+    EXPECT_EQ(records[0].wait_time_ns, 1500);
+    EXPECT_EQ(records[0].cpu_time_ns, 5000);
+}
+
+TEST_F(ProfilerRumContextTest, VitalsResetOnViewEnd) {
+    RumContextValues ctx = {};
+    ctx.application_id = "app-1";
+    ctx.session_id = "session-1";
+
+    // First view with some vitals
+    ctx.view_id = "view-1";
+    ctx.view_name = "Page1";
+    _profiler->UpdateRumContext(&ctx);
+    _profiler->AccumulateViewVitals(100, 200);
+
+    ctx.view_id = "";
+    ctx.view_name = "";
+    _profiler->UpdateRumContext(&ctx);
+
+    // Second view without any vitals
+    ctx.view_id = "view-2";
+    ctx.view_name = "Page2";
+    _profiler->UpdateRumContext(&ctx);
+
+    ctx.view_id = "";
+    ctx.view_name = "";
+    _profiler->UpdateRumContext(&ctx);
+
+    std::vector<RumViewRecord> records;
+    _profiler->ConsumeViewRecords(records);
+    ASSERT_EQ(records.size(), 2u);
+    EXPECT_EQ(records[0].wait_time_ns, 100);
+    EXPECT_EQ(records[0].cpu_time_ns, 200);
+    EXPECT_EQ(records[1].wait_time_ns, 0);
+    EXPECT_EQ(records[1].cpu_time_ns, 0);
+}
+
+TEST_F(ProfilerRumContextTest, VitalsResetOnNewViewStart) {
+    RumContextValues ctx = {};
+    ctx.application_id = "app-1";
+    ctx.session_id = "session-1";
+
+    // Start view and accumulate vitals
+    ctx.view_id = "view-1";
+    ctx.view_name = "Page1";
+    _profiler->UpdateRumContext(&ctx);
+    _profiler->AccumulateViewVitals(1000, 2000);
+
+    // Switch directly to a new view (without clearing)
+    ctx.view_id = "view-2";
+    ctx.view_name = "Page2";
+    _profiler->UpdateRumContext(&ctx);
+
+    // Accumulate for the second view
+    _profiler->AccumulateViewVitals(300, 400);
+
+    ctx.view_id = "";
+    ctx.view_name = "";
+    _profiler->UpdateRumContext(&ctx);
+
+    std::vector<RumViewRecord> records;
+    _profiler->ConsumeViewRecords(records);
+    ASSERT_EQ(records.size(), 1u);
+    EXPECT_EQ(records[0].view_id, "view-2");
+    EXPECT_EQ(records[0].wait_time_ns, 300);
+    EXPECT_EQ(records[0].cpu_time_ns, 400);
+}
+
+TEST_F(ProfilerRumContextTest, VitalsZeroWhenNoAccumulation) {
+    RumContextValues ctx = {};
+    ctx.application_id = "app-1";
+    ctx.session_id = "session-1";
+    ctx.view_id = "view-1";
+    ctx.view_name = "Page1";
+    _profiler->UpdateRumContext(&ctx);
+
+    // End the view without any AccumulateViewVitals calls
+    ctx.view_id = "";
+    ctx.view_name = "";
+    _profiler->UpdateRumContext(&ctx);
+
+    std::vector<RumViewRecord> records;
+    _profiler->ConsumeViewRecords(records);
+    ASSERT_EQ(records.size(), 1u);
+    EXPECT_EQ(records[0].cpu_time_ns, 0);
+    EXPECT_EQ(records[0].wait_time_ns, 0);
+}
+
+// ---------------------------------------------------------------------------
+// JSON vitals serialization tests
+// ---------------------------------------------------------------------------
+
+TEST(RumRecordJsonTests, VitalsInJson) {
+    std::vector<RumViewRecord> views = {
+        {1000, 500, "view-1", "Home", 123456789, 987654321}
+    };
+    std::vector<RumSessionRecord> sessions;
+    auto json = ProfileExporter::SerializeRumRecordsToJson(views, sessions);
+    EXPECT_NE(json.find("\"vitals\":{\"cpuTimeNs\":123456789,\"waitTimeNs\":987654321}"), std::string::npos);
+}
+
+TEST(RumRecordJsonTests, VitalsZeroInJson) {
+    std::vector<RumViewRecord> views = {
+        {1000, 500, "view-1", "Home", 0, 0}
+    };
+    std::vector<RumSessionRecord> sessions;
+    auto json = ProfileExporter::SerializeRumRecordsToJson(views, sessions);
+    EXPECT_NE(json.find("\"vitals\":{\"cpuTimeNs\":0,\"waitTimeNs\":0}"), std::string::npos);
+}
+
+TEST(RumRecordJsonTests, MultipleViewsWithDifferentVitals) {
+    std::vector<RumViewRecord> views = {
+        {1000, 500, "view-1", "Home", 100, 200},
+        {2000, 300, "view-2", "Settings", 400, 500}
+    };
+    std::vector<RumSessionRecord> sessions;
+    auto json = ProfileExporter::SerializeRumRecordsToJson(views, sessions);
+    EXPECT_NE(json.find("\"vitals\":{\"cpuTimeNs\":100,\"waitTimeNs\":200}"), std::string::npos);
+    EXPECT_NE(json.find("\"vitals\":{\"cpuTimeNs\":400,\"waitTimeNs\":500}"), std::string::npos);
 }

--- a/src/Tests/RumContextTests.cpp
+++ b/src/Tests/RumContextTests.cpp
@@ -14,6 +14,22 @@
 #include <sstream>
 #include <thread>
 
+// Helper: build a RumViewRecord with optional per-vital values.
+static RumViewRecord MakeViewRecord(
+    int64_t timestampMs, int64_t durationMs,
+    std::string viewId, std::string viewName,
+    int64_t cpuTimeNs = 0, int64_t waitTimeNs = 0)
+{
+    RumViewRecord r;
+    r.timestamp_ms = timestampMs;
+    r.duration_ms  = durationMs;
+    r.view_id      = std::move(viewId);
+    r.view_name    = std::move(viewName);
+    r.vitals_ns[static_cast<size_t>(ViewVitalKind::CpuTime)]  = cpuTimeNs;
+    r.vitals_ns[static_cast<size_t>(ViewVitalKind::WaitTime)] = waitTimeNs;
+    return r;
+}
+
 // ---------------------------------------------------------------------------
 // RumViewContext struct tests
 // ---------------------------------------------------------------------------
@@ -369,18 +385,24 @@ TEST(RumViewRecordTests, DefaultConstruction) {
     EXPECT_EQ(record.duration_ms, 0);
     EXPECT_TRUE(record.view_id.empty());
     EXPECT_TRUE(record.view_name.empty());
-    EXPECT_EQ(record.cpu_time_ns, 0);
-    EXPECT_EQ(record.wait_time_ns, 0);
+    for (size_t i = 0; i < ViewVitalKindCount; ++i)
+        EXPECT_EQ(record.vitals_ns[i], 0);
 }
 
 TEST(RumViewRecordTests, ValueInitialization) {
-    RumViewRecord record{1773058873970, 2000, "view-abc", "HomePage", 500000, 300000};
+    RumViewRecord record;
+    record.timestamp_ms = 1773058873970;
+    record.duration_ms = 2000;
+    record.view_id = "view-abc";
+    record.view_name = "HomePage";
+    record.vitals_ns[static_cast<size_t>(ViewVitalKind::CpuTime)] = 500000;
+    record.vitals_ns[static_cast<size_t>(ViewVitalKind::WaitTime)] = 300000;
     EXPECT_EQ(record.timestamp_ms, 1773058873970);
     EXPECT_EQ(record.duration_ms, 2000);
     EXPECT_EQ(record.view_id, "view-abc");
     EXPECT_EQ(record.view_name, "HomePage");
-    EXPECT_EQ(record.cpu_time_ns, 500000);
-    EXPECT_EQ(record.wait_time_ns, 300000);
+    EXPECT_EQ(record.vitals_ns[static_cast<size_t>(ViewVitalKind::CpuTime)], 500000);
+    EXPECT_EQ(record.vitals_ns[static_cast<size_t>(ViewVitalKind::WaitTime)], 300000);
 }
 
 // ---------------------------------------------------------------------------
@@ -523,7 +545,7 @@ TEST(RumRecordJsonTests, EmptyBothProducesEmptyJson) {
 
 TEST(RumRecordJsonTests, ViewsOnlyJson) {
     std::vector<RumViewRecord> views = {
-        {1773058873970, 2000, "view-1", "HomePage", 0, 0}
+        MakeViewRecord(1773058873970, 2000, "view-1", "HomePage")
     };
     std::vector<RumSessionRecord> sessions;
     auto json = ProfileExporter::SerializeRumRecordsToJson(views, sessions);
@@ -551,8 +573,8 @@ TEST(RumRecordJsonTests, SessionsOnlyJson) {
 
 TEST(RumRecordJsonTests, MixedViewsAndSessionsJson) {
     std::vector<RumViewRecord> views = {
-        {1773058873970, 2000, "view-1", "HomePage"},
-        {1773058876000, 1500, "view-2", "Settings"}
+        MakeViewRecord(1773058873970, 2000, "view-1", "HomePage"),
+        MakeViewRecord(1773058876000, 1500, "view-2", "Settings")
     };
     std::vector<RumSessionRecord> sessions = {
         {1773058870000, 8000, "session-1"}
@@ -568,7 +590,7 @@ TEST(RumRecordJsonTests, MixedViewsAndSessionsJson) {
 
 TEST(RumRecordJsonTests, ZeroDuration) {
     std::vector<RumViewRecord> views = {
-        {1773058873970, 0, "view-1", "Quick"}
+        MakeViewRecord(1773058873970, 0, "view-1", "Quick")
     };
     std::vector<RumSessionRecord> sessions;
     auto json = ProfileExporter::SerializeRumRecordsToJson(views, sessions);
@@ -773,8 +795,8 @@ TEST_F(ProfilerRumContextTest, VitalsAccumulateDuringActiveView) {
     std::vector<RumViewRecord> records;
     _profiler->ConsumeViewRecords(records);
     ASSERT_EQ(records.size(), 1u);
-    EXPECT_EQ(records[0].wait_time_ns, 1500);
-    EXPECT_EQ(records[0].cpu_time_ns, 5000);
+    EXPECT_EQ(records[0].vitals_ns[static_cast<size_t>(ViewVitalKind::WaitTime)], 1500);
+    EXPECT_EQ(records[0].vitals_ns[static_cast<size_t>(ViewVitalKind::CpuTime)], 5000);
 }
 
 TEST_F(ProfilerRumContextTest, VitalsResetOnViewEnd) {
@@ -805,10 +827,10 @@ TEST_F(ProfilerRumContextTest, VitalsResetOnViewEnd) {
     std::vector<RumViewRecord> records;
     _profiler->ConsumeViewRecords(records);
     ASSERT_EQ(records.size(), 2u);
-    EXPECT_EQ(records[0].wait_time_ns, 100);
-    EXPECT_EQ(records[0].cpu_time_ns, 200);
-    EXPECT_EQ(records[1].wait_time_ns, 0);
-    EXPECT_EQ(records[1].cpu_time_ns, 0);
+    EXPECT_EQ(records[0].vitals_ns[static_cast<size_t>(ViewVitalKind::WaitTime)], 100);
+    EXPECT_EQ(records[0].vitals_ns[static_cast<size_t>(ViewVitalKind::CpuTime)], 200);
+    EXPECT_EQ(records[1].vitals_ns[static_cast<size_t>(ViewVitalKind::WaitTime)], 0);
+    EXPECT_EQ(records[1].vitals_ns[static_cast<size_t>(ViewVitalKind::CpuTime)], 0);
 }
 
 TEST_F(ProfilerRumContextTest, VitalsResetOnNewViewStart) {
@@ -840,8 +862,8 @@ TEST_F(ProfilerRumContextTest, VitalsResetOnNewViewStart) {
     _profiler->ConsumeViewRecords(records);
     ASSERT_EQ(records.size(), 1u);
     EXPECT_EQ(records[0].view_id, "view-2");
-    EXPECT_EQ(records[0].wait_time_ns, 300);
-    EXPECT_EQ(records[0].cpu_time_ns, 400);
+    EXPECT_EQ(records[0].vitals_ns[static_cast<size_t>(ViewVitalKind::WaitTime)], 300);
+    EXPECT_EQ(records[0].vitals_ns[static_cast<size_t>(ViewVitalKind::CpuTime)], 400);
 }
 
 TEST_F(ProfilerRumContextTest, VitalsRejectOutOfRangeKind) {
@@ -863,8 +885,8 @@ TEST_F(ProfilerRumContextTest, VitalsRejectOutOfRangeKind) {
     std::vector<RumViewRecord> records;
     _profiler->ConsumeViewRecords(records);
     ASSERT_EQ(records.size(), 1u);
-    EXPECT_EQ(records[0].cpu_time_ns, 0);
-    EXPECT_EQ(records[0].wait_time_ns, 0);
+    for (size_t i = 0; i < ViewVitalKindCount; ++i)
+        EXPECT_EQ(records[0].vitals_ns[i], 0);
 }
 
 TEST_F(ProfilerRumContextTest, VitalsZeroWhenNoAccumulation) {
@@ -883,8 +905,8 @@ TEST_F(ProfilerRumContextTest, VitalsZeroWhenNoAccumulation) {
     std::vector<RumViewRecord> records;
     _profiler->ConsumeViewRecords(records);
     ASSERT_EQ(records.size(), 1u);
-    EXPECT_EQ(records[0].cpu_time_ns, 0);
-    EXPECT_EQ(records[0].wait_time_ns, 0);
+    for (size_t i = 0; i < ViewVitalKindCount; ++i)
+        EXPECT_EQ(records[0].vitals_ns[i], 0);
 }
 
 // ---------------------------------------------------------------------------
@@ -893,7 +915,7 @@ TEST_F(ProfilerRumContextTest, VitalsZeroWhenNoAccumulation) {
 
 TEST(RumRecordJsonTests, VitalsInJson) {
     std::vector<RumViewRecord> views = {
-        {1000, 500, "view-1", "Home", 123456789, 987654321}
+        MakeViewRecord(1000, 500, "view-1", "Home", 123456789, 987654321)
     };
     std::vector<RumSessionRecord> sessions;
     auto json = ProfileExporter::SerializeRumRecordsToJson(views, sessions);
@@ -902,7 +924,7 @@ TEST(RumRecordJsonTests, VitalsInJson) {
 
 TEST(RumRecordJsonTests, VitalsZeroInJson) {
     std::vector<RumViewRecord> views = {
-        {1000, 500, "view-1", "Home", 0, 0}
+        MakeViewRecord(1000, 500, "view-1", "Home")
     };
     std::vector<RumSessionRecord> sessions;
     auto json = ProfileExporter::SerializeRumRecordsToJson(views, sessions);
@@ -911,8 +933,8 @@ TEST(RumRecordJsonTests, VitalsZeroInJson) {
 
 TEST(RumRecordJsonTests, MultipleViewsWithDifferentVitals) {
     std::vector<RumViewRecord> views = {
-        {1000, 500, "view-1", "Home", 100, 200},
-        {2000, 300, "view-2", "Settings", 400, 500}
+        MakeViewRecord(1000, 500, "view-1", "Home", 100, 200),
+        MakeViewRecord(2000, 300, "view-2", "Settings", 400, 500)
     };
     std::vector<RumSessionRecord> sessions;
     auto json = ProfileExporter::SerializeRumRecordsToJson(views, sessions);

--- a/src/dd-win-prof/ProfileExporter.cpp
+++ b/src/dd-win-prof/ProfileExporter.cpp
@@ -1067,7 +1067,11 @@ std::string ProfileExporter::SerializeRumRecordsToJson(
         EscapeJsonString(ss, viewRecords[i].view_id);
         ss << "\",\"viewName\":\"";
         EscapeJsonString(ss, viewRecords[i].view_name);
-        ss << "\"}";
+        ss << "\",\"vitals\":{\"cpuTimeNs\":"
+           << viewRecords[i].cpu_time_ns
+           << ",\"waitTimeNs\":"
+           << viewRecords[i].wait_time_ns
+           << "}}";
     }
     ss << "],\"sessions\":[";
     for (size_t i = 0; i < sessionRecords.size(); ++i)

--- a/src/dd-win-prof/ProfileExporter.cpp
+++ b/src/dd-win-prof/ProfileExporter.cpp
@@ -241,26 +241,14 @@ bool ProfileExporter::Export(bool lastCall)
         return false;
     }
 
-    // Consume RUM view and session records, build session ID list for tag
+    // Consume RUM view and session records and serialize them to JSON.
+    // The same JSON is used for the local debug `.rum-views.json` file (if
+    // enabled) and is passed to libdatadog via `optional_internal_metadata_json`.
     std::string rumRecordsJson;
-    std::vector<std::string> allSessionIds;
     if (_pRumRecordProvider != nullptr)
     {
         _pRumRecordProvider->ConsumeViewRecords(_viewRecordsBuffer);
         _pRumRecordProvider->ConsumeSessionRecords(_sessionRecordsBuffer);
-        std::string currentSessionId = _pRumRecordProvider->GetCurrentSessionId();
-
-        for (const auto& rec : _sessionRecordsBuffer)
-        {
-            allSessionIds.push_back(rec.session_id);
-        }
-        if (!currentSessionId.empty())
-        {
-            if (std::find(allSessionIds.begin(), allSessionIds.end(), currentSessionId) == allSessionIds.end())
-            {
-                allSessionIds.push_back(currentSessionId);
-            }
-        }
 
         if (!_viewRecordsBuffer.empty() || !_sessionRecordsBuffer.empty())
         {
@@ -290,7 +278,7 @@ bool ProfileExporter::Export(bool lastCall)
     // Export profile to backend if enabled
     bool exportSuccess = true;
     if (_exportEnabled && _exporter.inner) {
-        exportSuccess = ExportProfile(encodedProfile, _currentExportId, rumRecordsJson, allSessionIds);
+        exportSuccess = ExportProfile(encodedProfile, _currentExportId, rumRecordsJson);
         if (!exportSuccess) {
             Log::Error("Failed to export profile to backend");
             // Continue with cleanup even if export failed
@@ -1245,8 +1233,7 @@ bool ProfileExporter::CreateExporterEndpoint(ddog_prof_Endpoint& endpoint)
 }
 
 bool ProfileExporter::ExportProfile(const ddog_prof_EncodedProfile* encodedProfile, uint32_t profileSeq,
-                                    const std::string& rumRecordsJson,
-                                    const std::vector<std::string>& allSessionIds)
+                                    const std::string& rumRecordsJson)
 {
     if (!_exporter.inner || !encodedProfile) {
         _lastError = "Exporter not initialized or invalid profile";
@@ -1255,7 +1242,7 @@ bool ProfileExporter::ExportProfile(const ddog_prof_EncodedProfile* encodedProfi
 
     // Prepare additional tags (per-export metadata)
     ddog_Vec_Tag additionalTags = ddog_Vec_Tag_new();
-    if (!PrepareAdditionalTags(additionalTags, profileSeq, allSessionIds)) {
+    if (!PrepareAdditionalTags(additionalTags, profileSeq)) {
         ddog_Vec_Tag_drop(additionalTags);
         return false;
     }
@@ -1268,27 +1255,26 @@ bool ProfileExporter::ExportProfile(const ddog_prof_EncodedProfile* encodedProfi
         return false;
     }
 
-    // Prepare optional RUM records file attachment
-    ddog_prof_Exporter_File rumFile;
-    ddog_prof_Exporter_Slice_File filesToCompress = ddog_prof_Exporter_Slice_File_empty();
+    // Pass the RUM records JSON through optional_internal_metadata_json.
+    // libdatadog embeds it in the `internal` field of the profile's event.json,
+    // so no separate file attachment is needed. The backing std::string must
+    // outlive the Request_build call; it's a function-scoped local.
+    ddog_CharSlice internalMetadataSlice{};
+    const ddog_CharSlice* internalMetadataPtr = nullptr;
     if (!rumRecordsJson.empty())
     {
-        rumFile.name = to_CharSlice("rum-views.json");
-        rumFile.file = {
-            reinterpret_cast<const uint8_t*>(rumRecordsJson.data()),
-            rumRecordsJson.size()
-        };
-        filesToCompress = { &rumFile, 1 };
+        internalMetadataSlice = to_CharSlice(rumRecordsJson);
+        internalMetadataPtr = &internalMetadataSlice;
     }
 
     // Build request - time information is now embedded in the EncodedProfile
     auto requestResult = ddog_prof_Exporter_Request_build(
         &_exporter,
         const_cast<ddog_prof_EncodedProfile*>(encodedProfile), // profile
-        filesToCompress,                        // files_to_compress_and_export
+        ddog_prof_Exporter_Slice_File_empty(), // files_to_compress_and_export
         ddog_prof_Exporter_Slice_File_empty(), // files_to_export_unmodified
         &additionalTags,                        // optional_additional_tags
-        nullptr,                                // optional_internal_metadata_json
+        internalMetadataPtr,                    // optional_internal_metadata_json
         nullptr                                 // optional_info_json
     );
 
@@ -1344,8 +1330,7 @@ bool ProfileExporter::ExportProfile(const ddog_prof_EncodedProfile* encodedProfi
     return responseOk;
 }
 
-bool ProfileExporter::PrepareAdditionalTags(ddog_Vec_Tag& tags, uint32_t profileSeq,
-                                             const std::vector<std::string>& allSessionIds)
+bool ProfileExporter::PrepareAdditionalTags(ddog_Vec_Tag& tags, uint32_t profileSeq)
 {
     // Add profile sequence number
     if (!AddSingleTag(tags, TAG_PROFILE_SEQ, std::to_string(profileSeq))) {
@@ -1364,17 +1349,9 @@ bool ProfileExporter::PrepareAdditionalTags(ddog_Vec_Tag& tags, uint32_t profile
         }
     }
 
-    // Add RUM session ID tag (comma-separated list of all sessions since last export)
-    if (!allSessionIds.empty()) {
-        std::string sessionIdList;
-        for (size_t i = 0; i < allSessionIds.size(); ++i) {
-            if (i > 0) sessionIdList += ',';
-            sessionIdList += allSessionIds[i];
-        }
-        if (!AddSingleTag(tags, TAG_RUM_SESSION_ID, sessionIdList)) {
-            return false;
-        }
-    }
+    // Note: RUM session IDs are no longer emitted as a tag. They are now
+    // embedded in the optional_internal_metadata_json payload under
+    // "rum_session_ids", alongside the per-view vitals.
 
     return true;
 }

--- a/src/dd-win-prof/ProfileExporter.cpp
+++ b/src/dd-win-prof/ProfileExporter.cpp
@@ -1056,9 +1056,9 @@ std::string ProfileExporter::SerializeRumRecordsToJson(
         ss << "\",\"viewName\":\"";
         EscapeJsonString(ss, viewRecords[i].view_name);
         ss << "\",\"vitals\":{\"cpuTimeNs\":"
-           << viewRecords[i].cpu_time_ns
+           << viewRecords[i].vitals_ns[static_cast<size_t>(ViewVitalKind::CpuTime)]
            << ",\"waitTimeNs\":"
-           << viewRecords[i].wait_time_ns
+           << viewRecords[i].vitals_ns[static_cast<size_t>(ViewVitalKind::WaitTime)]
            << "}}";
     }
     ss << "],\"sessions\":[";

--- a/src/dd-win-prof/ProfileExporter.h
+++ b/src/dd-win-prof/ProfileExporter.h
@@ -37,8 +37,16 @@ public:
     // RUM application ID tag (set once by Profiler, emitted per-export)
     void SetRumApplicationId(const std::string& applicationId);
 
-    // JSON serialization for RUM records (public so unit tests can exercise them directly)
-    // Note: public because needed for unit testing, but not intended for external use.
+    // JSON serialization for RUM records.
+    //
+    // The resulting JSON is used two ways:
+    //   1. Optionally written locally as a `.rum-views.json` debug file when
+    //      pprof file writing is enabled.
+    //   2. Passed to libdatadog through the `optional_internal_metadata_json`
+    //      parameter of `ddog_prof_Exporter_Request_build`, where it ends up
+    //      embedded in the `internal` field of the profile's `event.json`.
+    //
+    // Public so unit tests can exercise it directly; not intended for external use.
     static std::string SerializeRumRecordsToJson(
         const std::vector<RumViewRecord>& viewRecords,
         const std::vector<RumSessionRecord>& sessionRecords);
@@ -67,10 +75,8 @@ public:
     bool CreateExporterEndpoint(ddog_prof_Endpoint& endpoint);
     bool BuildExportUrl();
     bool ExportProfile(const ddog_prof_EncodedProfile* encodedProfile, uint32_t profileSeq,
-                       const std::string& rumRecordsJson = {},
-                       const std::vector<std::string>& allSessionIds = {});
-    bool PrepareAdditionalTags(ddog_Vec_Tag& tags, uint32_t profileSeq,
-                               const std::vector<std::string>& allSessionIds = {});
+                       const std::string& rumRecordsJson = {});
+    bool PrepareAdditionalTags(ddog_Vec_Tag& tags, uint32_t profileSeq);
     bool CheckExportResponse(uint16_t responseCode);
     void CleanupExporter();
 
@@ -123,7 +129,8 @@ private:
 
     // RUM tags (per-export)
     static constexpr const char* TAG_RUM_APPLICATION_ID = "rum.application_id";
-    static constexpr const char* TAG_RUM_SESSION_ID = "rum.session_id";
+    // Session IDs are no longer emitted as a tag; they are carried in the
+    // internal metadata JSON payload (optional_internal_metadata_json).
 
     // TODO: how to define metrics? With tags? With separate json file?
     static constexpr const char* TAG_RAM_SIZE = "ram_size";

--- a/src/dd-win-prof/Profiler.cpp
+++ b/src/dd-win-prof/Profiler.cpp
@@ -286,8 +286,17 @@ std::string Profiler::GetCurrentSessionId() const
     return _currentSessionId;
 }
 
-void Profiler::AccumulateViewVitals(int64_t waitTimeNs, int64_t cpuTimeNs)
+bool Profiler::AccumulateViewVitals(ViewVitalKind kind, int64_t valueNs)
 {
-    _pendingViewWaitTimeNs.fetch_add(waitTimeNs, std::memory_order_relaxed);
-    _pendingViewCpuTimeNs.fetch_add(cpuTimeNs, std::memory_order_relaxed);
+    switch (kind)
+    {
+    case ViewVitalKind::CpuTime:
+        _pendingViewCpuTimeNs.fetch_add(valueNs, std::memory_order_relaxed);
+        return true;
+    case ViewVitalKind::WaitTime:
+        _pendingViewWaitTimeNs.fetch_add(valueNs, std::memory_order_relaxed);
+        return true;
+    default:
+        return false;
+    }
 }

--- a/src/dd-win-prof/Profiler.cpp
+++ b/src/dd-win-prof/Profiler.cpp
@@ -49,6 +49,7 @@ bool Profiler::StartProfiling()
         _pThreadList.get(),
         _pCpuTimeProvider.get(),
         _pCpuWallTimeProvider.get(),
+        this,
         this);
 
     // get the values definition from the different providers...
@@ -221,6 +222,9 @@ bool Profiler::UpdateRumContext(const RumContextValues* pContext)
             _pendingViewStartMs = std::chrono::duration_cast<std::chrono::milliseconds>(
                 std::chrono::system_clock::now().time_since_epoch()).count();
             _hasPendingView = true;
+
+            _pendingViewCpuTimeNs.store(0, std::memory_order_relaxed);
+            _pendingViewWaitTimeNs.store(0, std::memory_order_relaxed);
         }
         else
         {
@@ -228,11 +232,18 @@ bool Profiler::UpdateRumContext(const RumContextValues* pContext)
             {
                 auto nowMs = std::chrono::duration_cast<std::chrono::milliseconds>(
                     std::chrono::system_clock::now().time_since_epoch()).count();
+                auto cpuNs = _pendingViewCpuTimeNs.load(std::memory_order_relaxed);
+                auto waitNs = _pendingViewWaitTimeNs.load(std::memory_order_relaxed);
+                _pendingViewCpuTimeNs.store(0, std::memory_order_relaxed);
+                _pendingViewWaitTimeNs.store(0, std::memory_order_relaxed);
+
                 _completedViewRecords.push_back({
                     _pendingViewStartMs,
                     nowMs - _pendingViewStartMs,
                     std::move(_currentRumView.view_id),
-                    std::move(_currentRumView.view_name)
+                    std::move(_currentRumView.view_name),
+                    cpuNs,
+                    waitNs
                 });
                 _hasPendingView = false;
             }
@@ -273,4 +284,10 @@ std::string Profiler::GetCurrentSessionId() const
 {
     std::shared_lock lock(_rumContextMutex);
     return _currentSessionId;
+}
+
+void Profiler::AccumulateViewVitals(int64_t waitTimeNs, int64_t cpuTimeNs)
+{
+    _pendingViewWaitTimeNs.fetch_add(waitTimeNs, std::memory_order_relaxed);
+    _pendingViewCpuTimeNs.fetch_add(cpuTimeNs, std::memory_order_relaxed);
 }

--- a/src/dd-win-prof/Profiler.cpp
+++ b/src/dd-win-prof/Profiler.cpp
@@ -238,7 +238,7 @@ bool Profiler::UpdateRumContext(const RumContextValues* pContext)
                 rec.duration_ms  = nowMs - _pendingViewStartMs;
                 rec.view_id      = std::move(_currentRumView.view_id);
                 rec.view_name    = std::move(_currentRumView.view_name);
-                for (size_t i = 0; i < ViewVitalKindCount; ++i)
+                for (size_t i = 0; i < MaxViewVitalKind; ++i)
                     rec.vitals_ns[i] = _pendingVitalsNs[i].exchange(0, std::memory_order_relaxed);
                 _completedViewRecords.push_back(std::move(rec));
                 _hasPendingView = false;
@@ -285,7 +285,7 @@ std::string Profiler::GetCurrentSessionId() const
 bool Profiler::AccumulateViewVitals(ViewVitalKind kind, int64_t valueNs)
 {
     auto idx = static_cast<size_t>(kind);
-    if (idx >= ViewVitalKindCount)
+    if (idx >= MaxViewVitalKind)
         return false;
 
     _pendingVitalsNs[idx].fetch_add(valueNs, std::memory_order_relaxed);

--- a/src/dd-win-prof/Profiler.cpp
+++ b/src/dd-win-prof/Profiler.cpp
@@ -223,8 +223,8 @@ bool Profiler::UpdateRumContext(const RumContextValues* pContext)
                 std::chrono::system_clock::now().time_since_epoch()).count();
             _hasPendingView = true;
 
-            _pendingViewCpuTimeNs.store(0, std::memory_order_relaxed);
-            _pendingViewWaitTimeNs.store(0, std::memory_order_relaxed);
+            for (auto& a : _pendingVitalsNs)
+                a.store(0, std::memory_order_relaxed);
         }
         else
         {
@@ -232,19 +232,15 @@ bool Profiler::UpdateRumContext(const RumContextValues* pContext)
             {
                 auto nowMs = std::chrono::duration_cast<std::chrono::milliseconds>(
                     std::chrono::system_clock::now().time_since_epoch()).count();
-                auto cpuNs = _pendingViewCpuTimeNs.load(std::memory_order_relaxed);
-                auto waitNs = _pendingViewWaitTimeNs.load(std::memory_order_relaxed);
-                _pendingViewCpuTimeNs.store(0, std::memory_order_relaxed);
-                _pendingViewWaitTimeNs.store(0, std::memory_order_relaxed);
 
-                _completedViewRecords.push_back({
-                    _pendingViewStartMs,
-                    nowMs - _pendingViewStartMs,
-                    std::move(_currentRumView.view_id),
-                    std::move(_currentRumView.view_name),
-                    cpuNs,
-                    waitNs
-                });
+                RumViewRecord rec;
+                rec.timestamp_ms = _pendingViewStartMs;
+                rec.duration_ms  = nowMs - _pendingViewStartMs;
+                rec.view_id      = std::move(_currentRumView.view_id);
+                rec.view_name    = std::move(_currentRumView.view_name);
+                for (size_t i = 0; i < ViewVitalKindCount; ++i)
+                    rec.vitals_ns[i] = _pendingVitalsNs[i].exchange(0, std::memory_order_relaxed);
+                _completedViewRecords.push_back(std::move(rec));
                 _hasPendingView = false;
             }
 
@@ -288,15 +284,10 @@ std::string Profiler::GetCurrentSessionId() const
 
 bool Profiler::AccumulateViewVitals(ViewVitalKind kind, int64_t valueNs)
 {
-    switch (kind)
-    {
-    case ViewVitalKind::CpuTime:
-        _pendingViewCpuTimeNs.fetch_add(valueNs, std::memory_order_relaxed);
-        return true;
-    case ViewVitalKind::WaitTime:
-        _pendingViewWaitTimeNs.fetch_add(valueNs, std::memory_order_relaxed);
-        return true;
-    default:
+    auto idx = static_cast<size_t>(kind);
+    if (idx >= ViewVitalKindCount)
         return false;
-    }
+
+    _pendingVitalsNs[idx].fetch_add(valueNs, std::memory_order_relaxed);
+    return true;
 }

--- a/src/dd-win-prof/Profiler.h
+++ b/src/dd-win-prof/Profiler.h
@@ -98,10 +98,10 @@ private:
     int64_t _pendingViewStartMs{0};
     bool _hasPendingView{false};
 
-    // Per-view vitals accumulators (written lock-free from sampler thread via fetch_add,
-    // read and reset under _rumContextMutex exclusive lock on view completion)
-    std::atomic<int64_t> _pendingViewCpuTimeNs{0};
-    std::atomic<int64_t> _pendingViewWaitTimeNs{0};
+    // Per-view vitals accumulators indexed by ViewVitalKind.
+    // Written lock-free from the sampler thread (fetch_add with relaxed ordering),
+    // read and reset under _rumContextMutex exclusive lock on view completion.
+    std::array<std::atomic<int64_t>, ViewVitalKindCount> _pendingVitalsNs{};
 
     // RUM session tracking (protected by _rumContextMutex)
     std::string _currentSessionId;

--- a/src/dd-win-prof/Profiler.h
+++ b/src/dd-win-prof/Profiler.h
@@ -101,7 +101,7 @@ private:
     // Per-view vitals accumulators indexed by ViewVitalKind.
     // Written lock-free from the sampler thread (fetch_add with relaxed ordering),
     // read and reset under _rumContextMutex exclusive lock on view completion.
-    std::array<std::atomic<int64_t>, ViewVitalKindCount> _pendingVitalsNs{};
+    std::array<std::atomic<int64_t>, MaxViewVitalKind> _pendingVitalsNs{};
 
     // RUM session tracking (protected by _rumContextMutex)
     std::string _currentSessionId;

--- a/src/dd-win-prof/Profiler.h
+++ b/src/dd-win-prof/Profiler.h
@@ -15,7 +15,7 @@
 #include "ThreadList.h"
 
 
-class Profiler : public IRumViewContextProvider, public IRumRecordProvider
+class Profiler : public IRumViewContextProvider, public IRumRecordProvider, public IViewVitalsAccumulator
 {
 public :
     Profiler();
@@ -41,6 +41,9 @@ public :
     void ConsumeViewRecords(std::vector<RumViewRecord>& records) override;
     void ConsumeSessionRecords(std::vector<RumSessionRecord>& records) override;
     std::string GetCurrentSessionId() const override;
+
+    // IViewVitalsAccumulator implementation (lock-free, called from sampler hot path)
+    void AccumulateViewVitals(int64_t waitTimeNs, int64_t cpuTimeNs) override;
 
 public:
     static Configuration* GetConfiguration()
@@ -94,6 +97,11 @@ private:
     std::vector<RumViewRecord> _completedViewRecords;
     int64_t _pendingViewStartMs{0};
     bool _hasPendingView{false};
+
+    // Per-view vitals accumulators (written lock-free from sampler thread via fetch_add,
+    // read and reset under _rumContextMutex exclusive lock on view completion)
+    std::atomic<int64_t> _pendingViewCpuTimeNs{0};
+    std::atomic<int64_t> _pendingViewWaitTimeNs{0};
 
     // RUM session tracking (protected by _rumContextMutex)
     std::string _currentSessionId;

--- a/src/dd-win-prof/Profiler.h
+++ b/src/dd-win-prof/Profiler.h
@@ -43,7 +43,7 @@ public :
     std::string GetCurrentSessionId() const override;
 
     // IViewVitalsAccumulator implementation (lock-free, called from sampler hot path)
-    void AccumulateViewVitals(int64_t waitTimeNs, int64_t cpuTimeNs) override;
+    bool AccumulateViewVitals(ViewVitalKind kind, int64_t valueNs) override;
 
 public:
     static Configuration* GetConfiguration()

--- a/src/dd-win-prof/RumContext.h
+++ b/src/dd-win-prof/RumContext.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <array>
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -12,13 +13,21 @@ struct RumViewContext {
     std::string view_name;
 };
 
+enum class ViewVitalKind : uint8_t
+{
+    CpuTime  = 0,
+    WaitTime = 1,
+    Unknown  // sentinel – must remain last
+};
+
+inline constexpr size_t ViewVitalKindCount = static_cast<size_t>(ViewVitalKind::Unknown);
+
 struct RumViewRecord {
     int64_t timestamp_ms{0};  // milliseconds since Unix epoch (view start)
     int64_t duration_ms{0};   // view duration in milliseconds
     std::string view_id;
     std::string view_name;
-    int64_t cpu_time_ns{0};   // cumulative CPU time collected during this view (nanoseconds)
-    int64_t wait_time_ns{0};  // cumulative wait time collected during this view (nanoseconds)
+    std::array<int64_t, ViewVitalKindCount> vitals_ns{};  // indexed by ViewVitalKind (nanoseconds)
 };
 
 struct RumSessionRecord {
@@ -34,13 +43,6 @@ public:
     // Returns true and fills 'context' with a copy of the current view if active.
     // Returns false if no view is currently active.
     virtual bool GetCurrentViewContext(RumViewContext& context) const = 0;
-};
-
-enum class ViewVitalKind : uint8_t
-{
-    CpuTime  = 0,
-    WaitTime = 1,
-    Unknown  // sentinel - must remain last
 };
 
 class IViewVitalsAccumulator {

--- a/src/dd-win-prof/RumContext.h
+++ b/src/dd-win-prof/RumContext.h
@@ -36,13 +36,21 @@ public:
     virtual bool GetCurrentViewContext(RumViewContext& context) const = 0;
 };
 
+enum class ViewVitalKind : uint8_t
+{
+    CpuTime  = 0,
+    WaitTime = 1,
+    Unknown  // sentinel - must remain last
+};
+
 class IViewVitalsAccumulator {
 public:
     virtual ~IViewVitalsAccumulator() = default;
 
     // Called from the sampler hot path (lock-free).
-    // Adds wait and CPU time to the currently active view's running totals.
-    virtual void AccumulateViewVitals(int64_t waitTimeNs, int64_t cpuTimeNs) = 0;
+    // Adds 'valueNs' nanoseconds to the running total for 'kind' on the
+    // currently active view. Returns false if 'kind' is out of range.
+    virtual bool AccumulateViewVitals(ViewVitalKind kind, int64_t valueNs) = 0;
 };
 
 class IRumRecordProvider {

--- a/src/dd-win-prof/RumContext.h
+++ b/src/dd-win-prof/RumContext.h
@@ -17,6 +17,8 @@ struct RumViewRecord {
     int64_t duration_ms{0};   // view duration in milliseconds
     std::string view_id;
     std::string view_name;
+    int64_t cpu_time_ns{0};   // cumulative CPU time collected during this view (nanoseconds)
+    int64_t wait_time_ns{0};  // cumulative wait time collected during this view (nanoseconds)
 };
 
 struct RumSessionRecord {
@@ -32,6 +34,15 @@ public:
     // Returns true and fills 'context' with a copy of the current view if active.
     // Returns false if no view is currently active.
     virtual bool GetCurrentViewContext(RumViewContext& context) const = 0;
+};
+
+class IViewVitalsAccumulator {
+public:
+    virtual ~IViewVitalsAccumulator() = default;
+
+    // Called from the sampler hot path (lock-free).
+    // Adds wait and CPU time to the currently active view's running totals.
+    virtual void AccumulateViewVitals(int64_t waitTimeNs, int64_t cpuTimeNs) = 0;
 };
 
 class IRumRecordProvider {

--- a/src/dd-win-prof/RumContext.h
+++ b/src/dd-win-prof/RumContext.h
@@ -20,14 +20,14 @@ enum class ViewVitalKind : uint8_t
     Unknown  // sentinel – must remain last
 };
 
-inline constexpr size_t ViewVitalKindCount = static_cast<size_t>(ViewVitalKind::Unknown);
+inline constexpr size_t MaxViewVitalKind = static_cast<size_t>(ViewVitalKind::Unknown);
 
 struct RumViewRecord {
     int64_t timestamp_ms{0};  // milliseconds since Unix epoch (view start)
     int64_t duration_ms{0};   // view duration in milliseconds
     std::string view_id;
     std::string view_name;
-    std::array<int64_t, ViewVitalKindCount> vitals_ns{};  // indexed by ViewVitalKind (nanoseconds)
+    std::array<int64_t, MaxViewVitalKind> vitals_ns{};  // indexed by ViewVitalKind (nanoseconds)
 };
 
 struct RumSessionRecord {

--- a/src/dd-win-prof/StackSamplerLoop.cpp
+++ b/src/dd-win-prof/StackSamplerLoop.cpp
@@ -298,7 +298,7 @@ void StackSamplerLoop::CollectOneThreadSample(std::shared_ptr<ThreadInfo>& pThre
 
             if (hasRumView && _pViewVitalsAccumulator != nullptr)
             {
-                _pViewVitalsAccumulator->AccumulateViewVitals(0, duration.count());
+                _pViewVitalsAccumulator->AccumulateViewVitals(ViewVitalKind::CpuTime, duration.count());
             }
         }
         else
@@ -335,7 +335,7 @@ void StackSamplerLoop::CollectOneThreadSample(std::shared_ptr<ThreadInfo>& pThre
 
             if (hasRumView && _pViewVitalsAccumulator != nullptr)
             {
-                _pViewVitalsAccumulator->AccumulateViewVitals(waitDuration.count(), 0);
+                _pViewVitalsAccumulator->AccumulateViewVitals(ViewVitalKind::WaitTime, waitDuration.count());
             }
         }
         else

--- a/src/dd-win-prof/StackSamplerLoop.cpp
+++ b/src/dd-win-prof/StackSamplerLoop.cpp
@@ -16,7 +16,8 @@ StackSamplerLoop::StackSamplerLoop(
     ThreadList* pThreadList,
     CpuTimeProvider* pCpuTimeProvider,
     WallTimeProvider* pWallTimeProvider,
-    IRumViewContextProvider* pRumViewContextProvider
+    IRumViewContextProvider* pRumViewContextProvider,
+    IViewVitalsAccumulator* pViewVitalsAccumulator
     )
     :
     _samplingPeriod(pConfiguration->CpuWallTimeSamplingPeriod()),
@@ -27,6 +28,7 @@ StackSamplerLoop::StackSamplerLoop(
     _pCpuTimeProvider(pCpuTimeProvider),
     _pWallTimeProvider(pWallTimeProvider),
     _pRumViewContextProvider(pRumViewContextProvider),
+    _pViewVitalsAccumulator(pViewVitalsAccumulator),
     _iteratorCpuTime(0),
     _iteratorWallTime(0),
     _pLoopThread(nullptr)
@@ -293,6 +295,11 @@ void StackSamplerLoop::CollectOneThreadSample(std::shared_ptr<ThreadInfo>& pThre
                 sample.SetRumViewContext(std::move(rumView));
             }
             _pCpuTimeProvider->Add(std::move(sample), duration);
+
+            if (hasRumView && _pViewVitalsAccumulator != nullptr)
+            {
+                _pViewVitalsAccumulator->AccumulateViewVitals(0, duration.count());
+            }
         }
         else
         if (profilingType == PROFILING_TYPE::WallTime)
@@ -325,6 +332,11 @@ void StackSamplerLoop::CollectOneThreadSample(std::shared_ptr<ThreadInfo>& pThre
                 sample.SetRumViewContext(std::move(rumView));
             }
             _pWallTimeProvider->Add(std::move(sample), duration, waitDuration, waitingReason);
+
+            if (hasRumView && _pViewVitalsAccumulator != nullptr)
+            {
+                _pViewVitalsAccumulator->AccumulateViewVitals(waitDuration.count(), 0);
+            }
         }
         else
         {

--- a/src/dd-win-prof/StackSamplerLoop.h
+++ b/src/dd-win-prof/StackSamplerLoop.h
@@ -31,7 +31,8 @@ public:
         ThreadList* pThreadList,
         CpuTimeProvider* pCpuTimeProvider,
         WallTimeProvider* pWallTimeProvider,
-        IRumViewContextProvider* pRumViewContextProvider = nullptr
+        IRumViewContextProvider* pRumViewContextProvider = nullptr,
+        IViewVitalsAccumulator* pViewVitalsAccumulator = nullptr
         );
     ~StackSamplerLoop();
 
@@ -72,5 +73,6 @@ private:
     CpuTimeProvider* _pCpuTimeProvider;
     WallTimeProvider* _pWallTimeProvider;
     IRumViewContextProvider* _pRumViewContextProvider;
+    IViewVitalsAccumulator* _pViewVitalsAccumulator;
 };
 

--- a/src/integration-tests/test_rum_scenario.ps1
+++ b/src/integration-tests/test_rum_scenario.ps1
@@ -170,7 +170,20 @@ foreach ($entry in $allViewEntries) {
         "startClocks.timeStamp > 0 for viewId=$($entry.viewId) (got $($entry.startClocks.timeStamp))"
     Assert ($entry.duration -gt 0) `
         "duration > 0 for viewId=$($entry.viewId) (got $($entry.duration))"
+    Assert ($null -ne $entry.vitals) `
+        "vitals object present for viewId=$($entry.viewId)"
+    if ($null -ne $entry.vitals) {
+        Assert ($entry.vitals.cpuTimeNs -ge 0) `
+            "vitals.cpuTimeNs >= 0 for viewId=$($entry.viewId) (got $($entry.vitals.cpuTimeNs))"
+        Assert ($entry.vitals.waitTimeNs -ge 0) `
+            "vitals.waitTimeNs >= 0 for viewId=$($entry.viewId) (got $($entry.vitals.waitTimeNs))"
+    }
 }
+
+# At least one view should have accumulated some CPU time (each view spins for 2s)
+$viewsWithCpu = $allViewEntries | Where-Object { $null -ne $_.vitals -and $_.vitals.cpuTimeNs -gt 0 }
+Assert ($viewsWithCpu.Count -gt 0) `
+    "At least one view has positive vitals.cpuTimeNs ($($viewsWithCpu.Count) found)"
 
 $expectedViewPairs = @(
     @{ ViewId = "11111111-1111-1111-1111-111111111111"; ViewName = "HomePage" },

--- a/src/integration-tests/test_rum_scenario.ps1
+++ b/src/integration-tests/test_rum_scenario.ps1
@@ -104,11 +104,7 @@ if ($logFiles.Count -gt 0) {
 $pprofFiles = Get-ChildItem -Path $pprofDir -Filter "*.pprof" -ErrorAction SilentlyContinue
 Assert ($pprofFiles.Count -gt 0) "At least one .pprof file was written ($($pprofFiles.Count) found)"
 
-$expectedViews = @(
-    @{ ViewId = "11111111-1111-1111-1111-111111111111"; ViewName = "HomePage" },
-    @{ ViewId = "22222222-2222-2222-2222-222222222222"; ViewName = "SettingsPage" },
-    @{ ViewId = "33333333-3333-3333-3333-333333333333"; ViewName = "ProfilePage" }
-)
+$expectedViewNames = @("HomePage", "SettingsPage", "ProfilePage")
 
 $allSamples = @()
 
@@ -124,13 +120,14 @@ foreach ($pprofFile in $pprofFiles) {
 
 Assert ($allSamples.Count -gt 0) "Parsed samples from pprof files ($($allSamples.Count) total)"
 
-foreach ($view in $expectedViews) {
+foreach ($viewName in $expectedViewNames) {
     $matching = $allSamples | Where-Object {
-        $_.labels.'rum.view_id' -eq $view.ViewId -and
-        $_.labels.'trace endpoint' -eq $view.ViewName
+        $_.labels.'trace endpoint' -eq $viewName -and
+        $_.labels.'rum.view_id' -ne $null -and
+        $_.labels.'rum.view_id' -ne ''
     }
     Assert ($matching.Count -gt 0) `
-        "Found samples with rum.view_id=$($view.ViewId) and trace endpoint=$($view.ViewName) ($($matching.Count) samples)"
+        "Found samples with trace endpoint=$viewName and a non-empty rum.view_id ($($matching.Count) samples)"
 }
 
 $noViewSamples = $allSamples | Where-Object {
@@ -185,18 +182,13 @@ $viewsWithCpu = $allViewEntries | Where-Object { $null -ne $_.vitals -and $_.vit
 Assert ($viewsWithCpu.Count -gt 0) `
     "At least one view has positive vitals.cpuTimeNs ($($viewsWithCpu.Count) found)"
 
-$expectedViewPairs = @(
-    @{ ViewId = "11111111-1111-1111-1111-111111111111"; ViewName = "HomePage" },
-    @{ ViewId = "22222222-2222-2222-2222-222222222222"; ViewName = "SettingsPage" },
-    @{ ViewId = "33333333-3333-3333-3333-333333333333"; ViewName = "ProfilePage" }
-)
-
-foreach ($vp in $expectedViewPairs) {
+foreach ($viewName in $expectedViewNames) {
     $matching = $allViewEntries | Where-Object {
-        $_.viewId -eq $vp.ViewId -and $_.viewName -eq $vp.ViewName
+        $_.viewName -eq $viewName -and
+        $_.viewId -ne $null -and $_.viewId -ne ''
     }
     Assert ($matching.Count -ge $Iterations) `
-        "Found $($matching.Count) entries for viewId=$($vp.ViewId), viewName=$($vp.ViewName) (expected >= $Iterations)"
+        "Found $($matching.Count) entries for viewName=$viewName with non-empty viewId (expected >= $Iterations)"
 }
 
 # -- Validate session records --------------------------------------------------

--- a/src/integration-tests/test_rum_scenario_send.ps1
+++ b/src/integration-tests/test_rum_scenario_send.ps1
@@ -108,11 +108,7 @@ if ($logFiles.Count -gt 0) {
 $pprofFiles = Get-ChildItem -Path $pprofDir -Filter "*.pprof" -ErrorAction SilentlyContinue
 Assert ($pprofFiles.Count -gt 0) "At least one .pprof file was written ($($pprofFiles.Count) found)"
 
-$expectedViews = @(
-    @{ ViewId = "11111111-1111-1111-1111-111111111111"; ViewName = "HomePage" },
-    @{ ViewId = "22222222-2222-2222-2222-222222222222"; ViewName = "SettingsPage" },
-    @{ ViewId = "33333333-3333-3333-3333-333333333333"; ViewName = "ProfilePage" }
-)
+$expectedViewNames = @("HomePage", "SettingsPage", "ProfilePage")
 
 $allSamples = @()
 
@@ -128,13 +124,14 @@ foreach ($pprofFile in $pprofFiles) {
 
 Assert ($allSamples.Count -gt 0) "Parsed samples from pprof files ($($allSamples.Count) total)"
 
-foreach ($view in $expectedViews) {
+foreach ($viewName in $expectedViewNames) {
     $matching = $allSamples | Where-Object {
-        $_.labels.'rum.view_id' -eq $view.ViewId -and
-        $_.labels.'trace endpoint' -eq $view.ViewName
+        $_.labels.'trace endpoint' -eq $viewName -and
+        $_.labels.'rum.view_id' -ne $null -and
+        $_.labels.'rum.view_id' -ne ''
     }
     Assert ($matching.Count -gt 0) `
-        "Found samples with rum.view_id=$($view.ViewId) and trace endpoint=$($view.ViewName) ($($matching.Count) samples)"
+        "Found samples with trace endpoint=$viewName and a non-empty rum.view_id ($($matching.Count) samples)"
 }
 
 $noViewSamples = $allSamples | Where-Object {
@@ -189,18 +186,13 @@ $viewsWithCpu = $allViewEntries | Where-Object { $null -ne $_.vitals -and $_.vit
 Assert ($viewsWithCpu.Count -gt 0) `
     "At least one view has positive vitals.cpuTimeNs ($($viewsWithCpu.Count) found)"
 
-$expectedViewPairs = @(
-    @{ ViewId = "11111111-1111-1111-1111-111111111111"; ViewName = "HomePage" },
-    @{ ViewId = "22222222-2222-2222-2222-222222222222"; ViewName = "SettingsPage" },
-    @{ ViewId = "33333333-3333-3333-3333-333333333333"; ViewName = "ProfilePage" }
-)
-
-foreach ($vp in $expectedViewPairs) {
+foreach ($viewName in $expectedViewNames) {
     $matching = $allViewEntries | Where-Object {
-        $_.viewId -eq $vp.ViewId -and $_.viewName -eq $vp.ViewName
+        $_.viewName -eq $viewName -and
+        $_.viewId -ne $null -and $_.viewId -ne ''
     }
     Assert ($matching.Count -ge $Iterations) `
-        "Found $($matching.Count) entries for viewId=$($vp.ViewId), viewName=$($vp.ViewName) (expected >= $Iterations)"
+        "Found $($matching.Count) entries for viewName=$viewName with non-empty viewId (expected >= $Iterations)"
 }
 
 # -- Validate session records --------------------------------------------------

--- a/src/integration-tests/test_rum_scenario_send.ps1
+++ b/src/integration-tests/test_rum_scenario_send.ps1
@@ -174,7 +174,20 @@ foreach ($entry in $allViewEntries) {
         "startClocks.timeStamp > 0 for viewId=$($entry.viewId) (got $($entry.startClocks.timeStamp))"
     Assert ($entry.duration -gt 0) `
         "duration > 0 for viewId=$($entry.viewId) (got $($entry.duration))"
+    Assert ($null -ne $entry.vitals) `
+        "vitals object present for viewId=$($entry.viewId)"
+    if ($null -ne $entry.vitals) {
+        Assert ($entry.vitals.cpuTimeNs -ge 0) `
+            "vitals.cpuTimeNs >= 0 for viewId=$($entry.viewId) (got $($entry.vitals.cpuTimeNs))"
+        Assert ($entry.vitals.waitTimeNs -ge 0) `
+            "vitals.waitTimeNs >= 0 for viewId=$($entry.viewId) (got $($entry.vitals.waitTimeNs))"
+    }
 }
+
+# At least one view should have accumulated some CPU time (each view spins for 2s)
+$viewsWithCpu = $allViewEntries | Where-Object { $null -ne $_.vitals -and $_.vitals.cpuTimeNs -gt 0 }
+Assert ($viewsWithCpu.Count -gt 0) `
+    "At least one view has positive vitals.cpuTimeNs ($($viewsWithCpu.Count) found)"
 
 $expectedViewPairs = @(
     @{ ViewId = "11111111-1111-1111-1111-111111111111"; ViewName = "HomePage" },


### PR DESCRIPTION
## Description
Compute, keeps track and serialize wait + CPU duration as vitals per view

## Motivation
Allow metrics computation and direct mapping with RUM from the profiling backend side

## Testing
<!-- How was this change tested? -->
- [x] Built successfully on Windows
- [x] Existing tests pass
- [x] New tests added (if applicable)
- [x] Manually tested

## Checklist
- [x] Code follows existing style
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented) 