### PR TITLE
Split RUM context API into session and view components

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -25,7 +25,8 @@ This is a Windows native profiler that performs CPU sampling and exports profile
 - Exports `EnterView()` and `LeaveCurrentView()` for RUM view navigation
 
 **`dd-win-rum-private.h`** - SDK-level RUM context API (exported but not public)
-- Exports `SetRumSession()`, `SetRumView()` and `ClearRumContext()` for fine-grained RUM context management
+- Exports `SetRumSession()` and `SetRumView()` for fine-grained RUM context management
+- Pass `nullptr` to `SetRumSession()` to end the current session
 
 ### Core Profiler Management
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -22,6 +22,10 @@ This is a Windows native profiler that performs CPU sampling and exports profile
 
 **`dd-win-prof.cpp/.h`** - Public external API for applications to control profiling
 - Exports `SetupProfiler()`, `StartProfiler()` and `StopProfiler()` functions for controlling the profiler
+- Exports `EnterView()` and `LeaveCurrentView()` for RUM view navigation
+
+**`dd-win-rum-private.h`** - SDK-level RUM context API (exported but not public)
+- Exports `SetRumSession()`, `SetRumView()` and `ClearRumContext()` for fine-grained RUM context management
 
 ### Core Profiler Management
 
@@ -172,7 +176,7 @@ Configuration is managed in `Configuration.cpp`. Values come from two sources, w
 
 1. **Environment variables** (`EnvironmentVariables.h`): sampling period (default 20ms), threads to sample (default 5 for walltime, 64 for CPU), upload period (default 60s), service metadata, API key, agent URL, etc.
 
-2. **`SetupProfiler(ProfilerConfig*)`** (`dd-win-prof.cpp`): Callers pass a `ProfilerConfig` struct; `InitializeConfiguration()` applies its fields to the shared `Configuration` instance.
+2. **`SetupProfiler(const ProfilerConfig*)`** (`dd-win-prof.cpp`): Callers pass a `ProfilerConfig` struct; `InitializeConfiguration()` applies its fields to the shared `Configuration` instance.
 
 **No-env-vars mode** (`ProfilerConfig.noEnvVars == true`): `ResetToDefaults()` is called first, then only explicit struct fields are applied. All environment variables are ignored. In this mode, `url` and `apiKey` are mandatory; `SetupProfiler` returns `false` if either is missing.
 

--- a/src/Runner/Runner.cpp
+++ b/src/Runner/Runner.cpp
@@ -9,7 +9,7 @@
 #include <string>
 #include <Windows.h>
 
-#include "..\reference\dd-win-prof.h"
+#include "..\dd-win-prof\dd-win-rum-private.h"
 #include "Helpers.h"
 #include "Spinner.h"
 
@@ -339,43 +339,12 @@ void RunWaitingThreads()
 
 // Scenario 5: RUM context view transitions
 
-static std::string GenerateViewId()
+void SetSession(const std::string& appId, const std::string& sessionId)
 {
-    static std::mt19937 rng(std::random_device{}());
-    std::uniform_int_distribution<uint32_t> dist(0, 0xFFFFFFFF);
-
-    char buf[37]; // 8-4-4-4-12 + NUL
-    auto r = [&]() { return dist(rng); };
-    std::snprintf(buf, sizeof(buf),
-        "%08x-%04x-%04x-%04x-%04x%08x",
-        r(),
-        r() & 0xFFFF,
-        (r() & 0x0FFF) | 0x4000,   // version 4
-        (r() & 0x3FFF) | 0x8000,   // variant 1
-        r() & 0xFFFF, r());
-    return buf;
-}
-
-void SetView(const std::string& appId, const std::string& sessionId,
-             const char* viewName)
-{
-    std::string viewId = GenerateViewId();
-    RumContextValues ctx = {};
+    RumSessionContext ctx = {};
     ctx.application_id = appId.c_str();
     ctx.session_id = sessionId.c_str();
-    ctx.view_id = viewId.c_str();
-    ctx.view_name = viewName;
-    UpdateRumContext(&ctx);
-}
-
-void ClearView(const std::string& appId, const std::string& sessionId)
-{
-    RumContextValues ctx = {};
-    ctx.application_id = appId.c_str();
-    ctx.session_id = sessionId.c_str();
-    ctx.view_id = nullptr;
-    ctx.view_name = nullptr;
-    UpdateRumContext(&ctx);
+    SetRumSession(&ctx);
 }
 
 // Per-view function chains: each view produces a distinct call stack.
@@ -438,25 +407,35 @@ void RunRumScenario(const std::string& appId, const std::string& sessionId)
 {
     static const std::string sessionId2 = "99999999-2222-3333-4444-555555555555";
 
-    SetView(appId, sessionId, "HomePage");
+    SetSession(appId, sessionId);
+
+    // Explicit leave between views
+    EnterView("HomePage");
     std::cout << "View 1: HomePage, session S1..." << std::endl;
     HomePageView();
 
-    ClearView(appId, sessionId);
-    SetView(appId, sessionId, "SettingsPage");
-    std::cout << "View 2: SettingsPage, session S1..." << std::endl;
-    SettingsPageView();
-
-    ClearView(appId, sessionId);
+    LeaveCurrentView();
     std::cout << "No active view, session S1 (spinning 1s)..." << std::endl;
     Spin(1000);
 
-    // Session rotation: switch from S1 to S2
-    SetView(appId, sessionId2, "ProfilePage");
-    std::cout << "View 3: ProfilePage, session S2..." << std::endl;
+    // Stacked view: SettingsPage completes HomePage's record automatically
+    EnterView("SettingsPage");
+    std::cout << "View 2: SettingsPage, session S1..." << std::endl;
+    SettingsPageView();
+
+    EnterView("ProfilePage");
+    std::cout << "View 3: ProfilePage, session S1 (stacked, completes SettingsPage)..." << std::endl;
     ProfilePageView();
 
-    ClearView(appId, sessionId2);
+    LeaveCurrentView();
+
+    // Session rotation: switch from S1 to S2
+    SetSession(appId, sessionId2);
+    EnterView("HomePage");
+    std::cout << "View 4: HomePage, session S2..." << std::endl;
+    HomePageView();
+
+    LeaveCurrentView();
 }
 
 

--- a/src/Tests/RumContextTests.cpp
+++ b/src/Tests/RumContextTests.cpp
@@ -82,8 +82,19 @@ protected:
     std::unique_ptr<Profiler> _profiler;
 };
 
-TEST_F(ProfilerRumContextTest, SetRumSessionReturnsFalseOnNull) {
-    EXPECT_FALSE(_profiler->SetRumSession(nullptr));
+TEST_F(ProfilerRumContextTest, SetRumSessionNullEndsSession) {
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-1";
+    sessionCtx.session_id = "S1";
+    EXPECT_TRUE(_profiler->SetRumSession(&sessionCtx));
+
+    EXPECT_TRUE(_profiler->SetRumSession(nullptr));
+    EXPECT_TRUE(_profiler->GetCurrentSessionId().empty());
+}
+
+TEST_F(ProfilerRumContextTest, SetRumSessionNullWithNoSessionIsNoOp) {
+    EXPECT_TRUE(_profiler->SetRumSession(nullptr));
+    EXPECT_TRUE(_profiler->GetCurrentSessionId().empty());
 }
 
 TEST_F(ProfilerRumContextTest, SetRumSessionReturnsFalseOnEmptyAppId) {
@@ -1011,10 +1022,10 @@ TEST(RumRecordJsonTests, MultipleViewsWithDifferentVitals) {
 // shape; no dedicated internal-metadata suite is needed.
 
 // ---------------------------------------------------------------------------
-// ClearRumContext tests
+// SetRumSession(nullptr) end-session tests
 // ---------------------------------------------------------------------------
 
-TEST_F(ProfilerRumContextTest, ClearRumContextCompletesRecords) {
+TEST_F(ProfilerRumContextTest, NullSessionCompletesRecords) {
     RumSessionContext sessionCtx = {};
     sessionCtx.application_id = "app-1";
     sessionCtx.session_id = "S1";
@@ -1027,7 +1038,7 @@ TEST_F(ProfilerRumContextTest, ClearRumContextCompletesRecords) {
 
     ::Sleep(50);
 
-    _profiler->ClearRumContext();
+    _profiler->SetRumSession(nullptr);
 
     std::vector<RumViewRecord> viewRecords;
     _profiler->ConsumeViewRecords(viewRecords);
@@ -1040,34 +1051,37 @@ TEST_F(ProfilerRumContextTest, ClearRumContextCompletesRecords) {
     ASSERT_EQ(sessionRecords.size(), 1u);
     EXPECT_EQ(sessionRecords[0].session_id, "S1");
 
-    // Verify state is clean
     RumViewContext viewCtx;
     EXPECT_FALSE(_profiler->GetCurrentViewContext(viewCtx));
     EXPECT_TRUE(_profiler->GetCurrentSessionId().empty());
 }
 
-TEST_F(ProfilerRumContextTest, ClearRumContextClearsAppId) {
+TEST_F(ProfilerRumContextTest, NullSessionPreservesAppId) {
     RumSessionContext sessionCtx = {};
     sessionCtx.application_id = "app-1";
     sessionCtx.session_id = "S1";
     EXPECT_TRUE(_profiler->SetRumSession(&sessionCtx));
 
-    _profiler->ClearRumContext();
+    _profiler->SetRumSession(nullptr);
 
-    // After clearing, a different app_id should be accepted
+    // Same app_id should still be accepted after ending the session
+    sessionCtx.session_id = "S2";
+    EXPECT_TRUE(_profiler->SetRumSession(&sessionCtx));
+
+    // A different app_id should still be rejected
     RumSessionContext sessionCtx2 = {};
     sessionCtx2.application_id = "app-2";
-    sessionCtx2.session_id = "S2";
-    EXPECT_TRUE(_profiler->SetRumSession(&sessionCtx2));
+    sessionCtx2.session_id = "S3";
+    EXPECT_FALSE(_profiler->SetRumSession(&sessionCtx2));
 }
 
-TEST_F(ProfilerRumContextTest, ClearRumContextAfterOnlySession) {
+TEST_F(ProfilerRumContextTest, NullSessionAfterOnlySession) {
     RumSessionContext sessionCtx = {};
     sessionCtx.application_id = "app-1";
     sessionCtx.session_id = "S1";
     _profiler->SetRumSession(&sessionCtx);
 
-    _profiler->ClearRumContext();
+    _profiler->SetRumSession(nullptr);
 
     std::vector<RumSessionRecord> sessionRecords;
     _profiler->ConsumeSessionRecords(sessionRecords);
@@ -1326,13 +1340,13 @@ TEST_F(ProfilerRumContextTest, LeaveCurrentViewWithNoViewReturnsFalse) {
     EXPECT_FALSE(_profiler->LeaveCurrentView());
 }
 
-TEST_F(ProfilerRumContextTest, SetRumViewAfterClearRumContextReturnsFalse) {
+TEST_F(ProfilerRumContextTest, SetRumViewAfterNullSessionReturnsFalse) {
     RumSessionContext sessionCtx = {};
     sessionCtx.application_id = "app-1";
     sessionCtx.session_id = "S1";
     _profiler->SetRumSession(&sessionCtx);
 
-    _profiler->ClearRumContext();
+    _profiler->SetRumSession(nullptr);
 
     RumViewValues viewVals = {};
     viewVals.view_id = "view-1";
@@ -1340,13 +1354,13 @@ TEST_F(ProfilerRumContextTest, SetRumViewAfterClearRumContextReturnsFalse) {
     EXPECT_FALSE(_profiler->SetRumView(&viewVals));
 }
 
-TEST_F(ProfilerRumContextTest, EnterViewAfterClearRumContextReturnsFalse) {
+TEST_F(ProfilerRumContextTest, EnterViewAfterNullSessionReturnsFalse) {
     RumSessionContext sessionCtx = {};
     sessionCtx.application_id = "app-1";
     sessionCtx.session_id = "S1";
     _profiler->SetRumSession(&sessionCtx);
 
-    _profiler->ClearRumContext();
+    _profiler->SetRumSession(nullptr);
 
     EXPECT_FALSE(_profiler->EnterView("Page1"));
 }

--- a/src/Tests/RumContextTests.cpp
+++ b/src/Tests/RumContextTests.cpp
@@ -10,6 +10,7 @@
 #include "../dd-win-prof/SampleValueType.h"
 #include "../dd-win-prof/ThreadInfo.h"
 #include "../dd-win-prof/dd-win-prof.h"
+#include "../dd-win-prof/dd-win-rum-private.h"
 #include <gtest/gtest.h>
 #include <sstream>
 #include <thread>
@@ -81,18 +82,48 @@ protected:
     std::unique_ptr<Profiler> _profiler;
 };
 
-TEST_F(ProfilerRumContextTest, UpdateRumContextReturnsfalseOnNull) {
-    EXPECT_FALSE(_profiler->UpdateRumContext(nullptr));
+TEST_F(ProfilerRumContextTest, SetRumSessionReturnsFalseOnNull) {
+    EXPECT_FALSE(_profiler->SetRumSession(nullptr));
+}
+
+TEST_F(ProfilerRumContextTest, SetRumSessionReturnsFalseOnEmptyAppId) {
+    RumSessionContext ctx = {};
+    ctx.application_id = "";
+    ctx.session_id = "S1";
+    EXPECT_FALSE(_profiler->SetRumSession(&ctx));
+}
+
+TEST_F(ProfilerRumContextTest, SetRumSessionReturnsFalseOnNullAppId) {
+    RumSessionContext ctx = {};
+    ctx.application_id = nullptr;
+    ctx.session_id = "S1";
+    EXPECT_FALSE(_profiler->SetRumSession(&ctx));
+}
+
+TEST_F(ProfilerRumContextTest, SetRumSessionReturnsFalseOnEmptySessionId) {
+    RumSessionContext ctx = {};
+    ctx.application_id = "app-1";
+    ctx.session_id = "";
+    EXPECT_FALSE(_profiler->SetRumSession(&ctx));
+}
+
+TEST_F(ProfilerRumContextTest, SetRumSessionReturnsFalseOnNullSessionId) {
+    RumSessionContext ctx = {};
+    ctx.application_id = "app-1";
+    ctx.session_id = nullptr;
+    EXPECT_FALSE(_profiler->SetRumSession(&ctx));
 }
 
 TEST_F(ProfilerRumContextTest, SetViewContextAndReadBack) {
-    RumContextValues ctx = {};
-    ctx.application_id = "app-id-1";
-    ctx.session_id = "session-id-1";
-    ctx.view_id = "view-id-1";
-    ctx.view_name = "HomePage";
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-id-1";
+    sessionCtx.session_id = "session-id-1";
+    EXPECT_TRUE(_profiler->SetRumSession(&sessionCtx));
 
-    EXPECT_TRUE(_profiler->UpdateRumContext(&ctx));
+    RumViewValues viewVals = {};
+    viewVals.view_id = "view-id-1";
+    viewVals.view_name = "HomePage";
+    EXPECT_TRUE(_profiler->SetRumView(&viewVals));
 
     RumViewContext viewCtx;
     EXPECT_TRUE(_profiler->GetCurrentViewContext(viewCtx));
@@ -101,62 +132,61 @@ TEST_F(ProfilerRumContextTest, SetViewContextAndReadBack) {
 }
 
 TEST_F(ProfilerRumContextTest, ClearViewWithNullViewId) {
-    // Set a view first
-    RumContextValues ctx = {};
-    ctx.application_id = "app-id-1";
-    ctx.session_id = "session-id-1";
-    ctx.view_id = "view-id-1";
-    ctx.view_name = "HomePage";
-    _profiler->UpdateRumContext(&ctx);
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-id-1";
+    sessionCtx.session_id = "session-id-1";
+    _profiler->SetRumSession(&sessionCtx);
 
-    // Clear view by passing null view_id
-    RumContextValues clearCtx = {};
-    clearCtx.application_id = "app-id-1";
-    clearCtx.session_id = "session-id-1";
-    clearCtx.view_id = nullptr;
-    clearCtx.view_name = nullptr;
-    EXPECT_TRUE(_profiler->UpdateRumContext(&clearCtx));
+    RumViewValues viewVals = {};
+    viewVals.view_id = "view-id-1";
+    viewVals.view_name = "HomePage";
+    _profiler->SetRumView(&viewVals);
+
+    viewVals.view_id = nullptr;
+    viewVals.view_name = nullptr;
+    EXPECT_TRUE(_profiler->SetRumView(&viewVals));
 
     RumViewContext viewCtx;
     EXPECT_FALSE(_profiler->GetCurrentViewContext(viewCtx));
 }
 
 TEST_F(ProfilerRumContextTest, ClearViewWithEmptyViewId) {
-    // Set a view first
-    RumContextValues ctx = {};
-    ctx.application_id = "app-id-1";
-    ctx.session_id = "session-id-1";
-    ctx.view_id = "view-id-1";
-    ctx.view_name = "HomePage";
-    _profiler->UpdateRumContext(&ctx);
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-id-1";
+    sessionCtx.session_id = "session-id-1";
+    _profiler->SetRumSession(&sessionCtx);
 
-    // Clear view by passing empty view_id
-    RumContextValues clearCtx = {};
-    clearCtx.application_id = "app-id-1";
-    clearCtx.session_id = "session-id-1";
-    clearCtx.view_id = "";
-    clearCtx.view_name = "";
-    EXPECT_TRUE(_profiler->UpdateRumContext(&clearCtx));
+    RumViewValues viewVals = {};
+    viewVals.view_id = "view-id-1";
+    viewVals.view_name = "HomePage";
+    _profiler->SetRumView(&viewVals);
+
+    viewVals.view_id = "";
+    viewVals.view_name = "";
+    EXPECT_TRUE(_profiler->SetRumView(&viewVals));
 
     RumViewContext viewCtx;
     EXPECT_FALSE(_profiler->GetCurrentViewContext(viewCtx));
 }
 
 TEST_F(ProfilerRumContextTest, AppIdSetOnce) {
-    RumContextValues ctx1 = {};
-    ctx1.application_id = "app-1";
-    ctx1.session_id = "session-1";
-    ctx1.view_id = "view-1";
-    ctx1.view_name = "Page1";
-    EXPECT_TRUE(_profiler->UpdateRumContext(&ctx1));
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-1";
+    sessionCtx.session_id = "session-1";
+    EXPECT_TRUE(_profiler->SetRumSession(&sessionCtx));
+
+    RumViewValues viewVals = {};
+    viewVals.view_id = "view-1";
+    viewVals.view_name = "Page1";
+    _profiler->SetRumView(&viewVals);
 
     // Same app_id with different session_id should succeed (session is mutable)
-    RumContextValues ctx1b = {};
-    ctx1b.application_id = "app-1";
-    ctx1b.session_id = "session-2";
-    ctx1b.view_id = "view-1b";
-    ctx1b.view_name = "Page1b";
-    EXPECT_TRUE(_profiler->UpdateRumContext(&ctx1b));
+    sessionCtx.session_id = "session-2";
+    EXPECT_TRUE(_profiler->SetRumSession(&sessionCtx));
+
+    viewVals.view_id = "view-1b";
+    viewVals.view_name = "Page1b";
+    _profiler->SetRumView(&viewVals);
 
     RumViewContext viewCtx;
     EXPECT_TRUE(_profiler->GetCurrentViewContext(viewCtx));
@@ -164,20 +194,21 @@ TEST_F(ProfilerRumContextTest, AppIdSetOnce) {
 }
 
 TEST_F(ProfilerRumContextTest, DifferentAppIdRejected) {
-    RumContextValues ctx1 = {};
-    ctx1.application_id = "app-1";
-    ctx1.session_id = "session-1";
-    ctx1.view_id = "view-1";
-    ctx1.view_name = "Page1";
-    EXPECT_TRUE(_profiler->UpdateRumContext(&ctx1));
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-1";
+    sessionCtx.session_id = "session-1";
+    EXPECT_TRUE(_profiler->SetRumSession(&sessionCtx));
+
+    RumViewValues viewVals = {};
+    viewVals.view_id = "view-1";
+    viewVals.view_name = "Page1";
+    _profiler->SetRumView(&viewVals);
 
     // Different application_id should be rejected (view unchanged)
-    RumContextValues ctx2 = {};
-    ctx2.application_id = "app-2";
-    ctx2.session_id = "session-1";
-    ctx2.view_id = "view-2";
-    ctx2.view_name = "Page2";
-    EXPECT_FALSE(_profiler->UpdateRumContext(&ctx2));
+    RumSessionContext sessionCtx2 = {};
+    sessionCtx2.application_id = "app-2";
+    sessionCtx2.session_id = "session-1";
+    EXPECT_FALSE(_profiler->SetRumSession(&sessionCtx2));
 
     RumViewContext viewCtx;
     EXPECT_TRUE(_profiler->GetCurrentViewContext(viewCtx));
@@ -192,50 +223,56 @@ TEST_F(ProfilerRumContextTest, NoActiveViewByDefault) {
 
 TEST_F(ProfilerRumContextTest, ViewTransitionPattern) {
     // Simulates the real callback pattern: set view -> clear -> set new view
-    RumContextValues ctx = {};
-    ctx.application_id = "app-1";
-    ctx.session_id = "session-1";
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-1";
+    sessionCtx.session_id = "session-1";
+    _profiler->SetRumSession(&sessionCtx);
+
+    RumViewValues viewVals = {};
 
     // Set first view
-    ctx.view_id = "view-1";
-    ctx.view_name = "HomePage";
-    _profiler->UpdateRumContext(&ctx);
+    viewVals.view_id = "view-1";
+    viewVals.view_name = "HomePage";
+    _profiler->SetRumView(&viewVals);
 
     RumViewContext viewCtx;
     EXPECT_TRUE(_profiler->GetCurrentViewContext(viewCtx));
     EXPECT_EQ(viewCtx.view_id, "view-1");
 
     // Clear view (between views)
-    ctx.view_id = nullptr;
-    ctx.view_name = nullptr;
-    _profiler->UpdateRumContext(&ctx);
+    viewVals.view_id = nullptr;
+    viewVals.view_name = nullptr;
+    _profiler->SetRumView(&viewVals);
     EXPECT_FALSE(_profiler->GetCurrentViewContext(viewCtx));
 
     // Set second view
-    ctx.view_id = "view-2";
-    ctx.view_name = "SettingsPage";
-    _profiler->UpdateRumContext(&ctx);
+    viewVals.view_id = "view-2";
+    viewVals.view_name = "SettingsPage";
+    _profiler->SetRumView(&viewVals);
     EXPECT_TRUE(_profiler->GetCurrentViewContext(viewCtx));
     EXPECT_EQ(viewCtx.view_id, "view-2");
     EXPECT_EQ(viewCtx.view_name, "SettingsPage");
 }
 
 TEST_F(ProfilerRumContextTest, ViewContextCopyIsIndependent) {
-    RumContextValues ctx = {};
-    ctx.application_id = "app-1";
-    ctx.session_id = "session-1";
-    ctx.view_id = "view-1";
-    ctx.view_name = "HomePage";
-    _profiler->UpdateRumContext(&ctx);
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-1";
+    sessionCtx.session_id = "session-1";
+    _profiler->SetRumSession(&sessionCtx);
+
+    RumViewValues viewVals = {};
+    viewVals.view_id = "view-1";
+    viewVals.view_name = "HomePage";
+    _profiler->SetRumView(&viewVals);
 
     // Get a copy of the view context
     RumViewContext snapshot;
     EXPECT_TRUE(_profiler->GetCurrentViewContext(snapshot));
 
     // Update to a new view
-    ctx.view_id = "view-2";
-    ctx.view_name = "SettingsPage";
-    _profiler->UpdateRumContext(&ctx);
+    viewVals.view_id = "view-2";
+    viewVals.view_name = "SettingsPage";
+    _profiler->SetRumView(&viewVals);
 
     // The snapshot should still hold the old values
     EXPECT_EQ(snapshot.view_id, "view-1");
@@ -416,22 +453,25 @@ TEST_F(ProfilerRumContextTest, ConsumeViewRecordsEmptyByDefault) {
 }
 
 TEST_F(ProfilerRumContextTest, SetAndClearViewProducesOneRecord) {
-    RumContextValues ctx = {};
-    ctx.application_id = "app-1";
-    ctx.session_id = "session-1";
-    ctx.view_id = "view-1";
-    ctx.view_name = "HomePage";
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-1";
+    sessionCtx.session_id = "session-1";
+    _profiler->SetRumSession(&sessionCtx);
+
+    RumViewValues viewVals = {};
+    viewVals.view_id = "view-1";
+    viewVals.view_name = "HomePage";
 
     auto beforeMs = std::chrono::duration_cast<std::chrono::milliseconds>(
         std::chrono::system_clock::now().time_since_epoch()).count();
 
-    _profiler->UpdateRumContext(&ctx);
+    _profiler->SetRumView(&viewVals);
     ::Sleep(50);
 
     // Clear the view
-    ctx.view_id = "";
-    ctx.view_name = "";
-    _profiler->UpdateRumContext(&ctx);
+    viewVals.view_id = "";
+    viewVals.view_name = "";
+    _profiler->SetRumView(&viewVals);
 
     auto afterMs = std::chrono::duration_cast<std::chrono::milliseconds>(
         std::chrono::system_clock::now().time_since_epoch()).count();
@@ -448,16 +488,19 @@ TEST_F(ProfilerRumContextTest, SetAndClearViewProducesOneRecord) {
 }
 
 TEST_F(ProfilerRumContextTest, ConsumeSwapsBufferSecondCallEmpty) {
-    RumContextValues ctx = {};
-    ctx.application_id = "app-1";
-    ctx.session_id = "session-1";
-    ctx.view_id = "view-1";
-    ctx.view_name = "Page1";
-    _profiler->UpdateRumContext(&ctx);
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-1";
+    sessionCtx.session_id = "session-1";
+    _profiler->SetRumSession(&sessionCtx);
 
-    ctx.view_id = "";
-    ctx.view_name = "";
-    _profiler->UpdateRumContext(&ctx);
+    RumViewValues viewVals = {};
+    viewVals.view_id = "view-1";
+    viewVals.view_name = "Page1";
+    _profiler->SetRumView(&viewVals);
+
+    viewVals.view_id = "";
+    viewVals.view_name = "";
+    _profiler->SetRumView(&viewVals);
 
     std::vector<RumViewRecord> records;
     _profiler->ConsumeViewRecords(records);
@@ -469,12 +512,15 @@ TEST_F(ProfilerRumContextTest, ConsumeSwapsBufferSecondCallEmpty) {
 }
 
 TEST_F(ProfilerRumContextTest, PendingViewProducesNoRecord) {
-    RumContextValues ctx = {};
-    ctx.application_id = "app-1";
-    ctx.session_id = "session-1";
-    ctx.view_id = "view-1";
-    ctx.view_name = "Page1";
-    _profiler->UpdateRumContext(&ctx);
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-1";
+    sessionCtx.session_id = "session-1";
+    _profiler->SetRumSession(&sessionCtx);
+
+    RumViewValues viewVals = {};
+    viewVals.view_id = "view-1";
+    viewVals.view_name = "Page1";
+    _profiler->SetRumView(&viewVals);
 
     std::vector<RumViewRecord> records;
     _profiler->ConsumeViewRecords(records);
@@ -482,12 +528,15 @@ TEST_F(ProfilerRumContextTest, PendingViewProducesNoRecord) {
 }
 
 TEST_F(ProfilerRumContextTest, ClearWithoutSetProducesNoRecord) {
-    RumContextValues ctx = {};
-    ctx.application_id = "app-1";
-    ctx.session_id = "session-1";
-    ctx.view_id = "";
-    ctx.view_name = "";
-    _profiler->UpdateRumContext(&ctx);
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-1";
+    sessionCtx.session_id = "session-1";
+    _profiler->SetRumSession(&sessionCtx);
+
+    RumViewValues viewVals = {};
+    viewVals.view_id = "";
+    viewVals.view_name = "";
+    _profiler->SetRumView(&viewVals);
 
     std::vector<RumViewRecord> records;
     _profiler->ConsumeViewRecords(records);
@@ -495,31 +544,34 @@ TEST_F(ProfilerRumContextTest, ClearWithoutSetProducesNoRecord) {
 }
 
 TEST_F(ProfilerRumContextTest, ViewTransitionsProduceMultipleRecords) {
-    RumContextValues ctx = {};
-    ctx.application_id = "app-1";
-    ctx.session_id = "session-1";
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-1";
+    sessionCtx.session_id = "session-1";
+    _profiler->SetRumSession(&sessionCtx);
+
+    RumViewValues viewVals = {};
 
     // View 1
-    ctx.view_id = "view-1";
-    ctx.view_name = "Page1";
-    _profiler->UpdateRumContext(&ctx);
+    viewVals.view_id = "view-1";
+    viewVals.view_name = "Page1";
+    _profiler->SetRumView(&viewVals);
     ::Sleep(20);
 
     // Clear view 1
-    ctx.view_id = "";
-    ctx.view_name = "";
-    _profiler->UpdateRumContext(&ctx);
+    viewVals.view_id = "";
+    viewVals.view_name = "";
+    _profiler->SetRumView(&viewVals);
 
     // View 2
-    ctx.view_id = "view-2";
-    ctx.view_name = "Page2";
-    _profiler->UpdateRumContext(&ctx);
+    viewVals.view_id = "view-2";
+    viewVals.view_name = "Page2";
+    _profiler->SetRumView(&viewVals);
     ::Sleep(20);
 
     // Clear view 2
-    ctx.view_id = "";
-    ctx.view_name = "";
-    _profiler->UpdateRumContext(&ctx);
+    viewVals.view_id = "";
+    viewVals.view_name = "";
+    _profiler->SetRumView(&viewVals);
 
     std::vector<RumViewRecord> records;
     _profiler->ConsumeViewRecords(records);
@@ -661,36 +713,30 @@ TEST(RumSessionRecordTests, ValueInitialization) {
 // ---------------------------------------------------------------------------
 
 TEST_F(ProfilerRumContextTest, SessionIdCanChange) {
-    RumContextValues ctx = {};
-    ctx.application_id = "app-1";
-    ctx.session_id = "S1";
-    ctx.view_id = "view-1";
-    ctx.view_name = "Page1";
-    EXPECT_TRUE(_profiler->UpdateRumContext(&ctx));
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-1";
+    sessionCtx.session_id = "S1";
+    EXPECT_TRUE(_profiler->SetRumSession(&sessionCtx));
     EXPECT_EQ(_profiler->GetCurrentSessionId(), "S1");
 
-    ctx.session_id = "S2";
-    ctx.view_id = "view-2";
-    ctx.view_name = "Page2";
-    EXPECT_TRUE(_profiler->UpdateRumContext(&ctx));
+    sessionCtx.session_id = "S2";
+    EXPECT_TRUE(_profiler->SetRumSession(&sessionCtx));
     EXPECT_EQ(_profiler->GetCurrentSessionId(), "S2");
 }
 
 TEST_F(ProfilerRumContextTest, SessionIdChangeCompletesRecord) {
-    RumContextValues ctx = {};
-    ctx.application_id = "app-1";
-    ctx.session_id = "S1";
-    ctx.view_id = "view-1";
-    ctx.view_name = "Page1";
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-1";
+    sessionCtx.session_id = "S1";
 
     auto beforeMs = std::chrono::duration_cast<std::chrono::milliseconds>(
         std::chrono::system_clock::now().time_since_epoch()).count();
 
-    _profiler->UpdateRumContext(&ctx);
+    _profiler->SetRumSession(&sessionCtx);
     ::Sleep(50);
 
-    ctx.session_id = "S2";
-    _profiler->UpdateRumContext(&ctx);
+    sessionCtx.session_id = "S2";
+    _profiler->SetRumSession(&sessionCtx);
 
     std::vector<RumSessionRecord> records;
     _profiler->ConsumeSessionRecords(records);
@@ -701,21 +747,19 @@ TEST_F(ProfilerRumContextTest, SessionIdChangeCompletesRecord) {
 }
 
 TEST_F(ProfilerRumContextTest, MultipleSessionTransitions) {
-    RumContextValues ctx = {};
-    ctx.application_id = "app-1";
-    ctx.view_id = "view-1";
-    ctx.view_name = "Page1";
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-1";
 
-    ctx.session_id = "S1";
-    _profiler->UpdateRumContext(&ctx);
+    sessionCtx.session_id = "S1";
+    _profiler->SetRumSession(&sessionCtx);
     ::Sleep(20);
 
-    ctx.session_id = "S2";
-    _profiler->UpdateRumContext(&ctx);
+    sessionCtx.session_id = "S2";
+    _profiler->SetRumSession(&sessionCtx);
     ::Sleep(20);
 
-    ctx.session_id = "S3";
-    _profiler->UpdateRumContext(&ctx);
+    sessionCtx.session_id = "S3";
+    _profiler->SetRumSession(&sessionCtx);
 
     std::vector<RumSessionRecord> records;
     _profiler->ConsumeSessionRecords(records);
@@ -734,15 +778,13 @@ TEST_F(ProfilerRumContextTest, ConsumeSessionRecordsEmptyByDefault) {
 }
 
 TEST_F(ProfilerRumContextTest, ConsumeSessionRecordsSwapsBuffer) {
-    RumContextValues ctx = {};
-    ctx.application_id = "app-1";
-    ctx.session_id = "S1";
-    ctx.view_id = "view-1";
-    ctx.view_name = "Page1";
-    _profiler->UpdateRumContext(&ctx);
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-1";
+    sessionCtx.session_id = "S1";
+    _profiler->SetRumSession(&sessionCtx);
 
-    ctx.session_id = "S2";
-    _profiler->UpdateRumContext(&ctx);
+    sessionCtx.session_id = "S2";
+    _profiler->SetRumSession(&sessionCtx);
 
     std::vector<RumSessionRecord> records;
     _profiler->ConsumeSessionRecords(records);
@@ -754,16 +796,19 @@ TEST_F(ProfilerRumContextTest, ConsumeSessionRecordsSwapsBuffer) {
 }
 
 TEST_F(ProfilerRumContextTest, SameSessionIdDoesNotCreateRecord) {
-    RumContextValues ctx = {};
-    ctx.application_id = "app-1";
-    ctx.session_id = "S1";
-    ctx.view_id = "view-1";
-    ctx.view_name = "Page1";
-    _profiler->UpdateRumContext(&ctx);
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-1";
+    sessionCtx.session_id = "S1";
+    _profiler->SetRumSession(&sessionCtx);
 
-    ctx.view_id = "view-2";
-    ctx.view_name = "Page2";
-    _profiler->UpdateRumContext(&ctx);
+    RumViewValues viewVals = {};
+    viewVals.view_id = "view-1";
+    viewVals.view_name = "Page1";
+    _profiler->SetRumView(&viewVals);
+
+    viewVals.view_id = "view-2";
+    viewVals.view_name = "Page2";
+    _profiler->SetRumView(&viewVals);
 
     std::vector<RumSessionRecord> records;
     _profiler->ConsumeSessionRecords(records);
@@ -775,12 +820,15 @@ TEST_F(ProfilerRumContextTest, SameSessionIdDoesNotCreateRecord) {
 // ---------------------------------------------------------------------------
 
 TEST_F(ProfilerRumContextTest, VitalsAccumulateDuringActiveView) {
-    RumContextValues ctx = {};
-    ctx.application_id = "app-1";
-    ctx.session_id = "session-1";
-    ctx.view_id = "view-1";
-    ctx.view_name = "HomePage";
-    _profiler->UpdateRumContext(&ctx);
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-1";
+    sessionCtx.session_id = "session-1";
+    _profiler->SetRumSession(&sessionCtx);
+
+    RumViewValues viewVals = {};
+    viewVals.view_id = "view-1";
+    viewVals.view_name = "HomePage";
+    _profiler->SetRumView(&viewVals);
 
     EXPECT_TRUE(_profiler->AccumulateViewVitals(ViewVitalKind::WaitTime, 1000));
     EXPECT_TRUE(_profiler->AccumulateViewVitals(ViewVitalKind::CpuTime, 2000));
@@ -788,9 +836,9 @@ TEST_F(ProfilerRumContextTest, VitalsAccumulateDuringActiveView) {
     EXPECT_TRUE(_profiler->AccumulateViewVitals(ViewVitalKind::CpuTime, 3000));
 
     // End the view
-    ctx.view_id = "";
-    ctx.view_name = "";
-    _profiler->UpdateRumContext(&ctx);
+    viewVals.view_id = "";
+    viewVals.view_name = "";
+    _profiler->SetRumView(&viewVals);
 
     std::vector<RumViewRecord> records;
     _profiler->ConsumeViewRecords(records);
@@ -800,29 +848,32 @@ TEST_F(ProfilerRumContextTest, VitalsAccumulateDuringActiveView) {
 }
 
 TEST_F(ProfilerRumContextTest, VitalsResetOnViewEnd) {
-    RumContextValues ctx = {};
-    ctx.application_id = "app-1";
-    ctx.session_id = "session-1";
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-1";
+    sessionCtx.session_id = "session-1";
+    _profiler->SetRumSession(&sessionCtx);
+
+    RumViewValues viewVals = {};
 
     // First view with some vitals
-    ctx.view_id = "view-1";
-    ctx.view_name = "Page1";
-    _profiler->UpdateRumContext(&ctx);
+    viewVals.view_id = "view-1";
+    viewVals.view_name = "Page1";
+    _profiler->SetRumView(&viewVals);
     _profiler->AccumulateViewVitals(ViewVitalKind::WaitTime, 100);
     _profiler->AccumulateViewVitals(ViewVitalKind::CpuTime, 200);
 
-    ctx.view_id = "";
-    ctx.view_name = "";
-    _profiler->UpdateRumContext(&ctx);
+    viewVals.view_id = "";
+    viewVals.view_name = "";
+    _profiler->SetRumView(&viewVals);
 
     // Second view without any vitals
-    ctx.view_id = "view-2";
-    ctx.view_name = "Page2";
-    _profiler->UpdateRumContext(&ctx);
+    viewVals.view_id = "view-2";
+    viewVals.view_name = "Page2";
+    _profiler->SetRumView(&viewVals);
 
-    ctx.view_id = "";
-    ctx.view_name = "";
-    _profiler->UpdateRumContext(&ctx);
+    viewVals.view_id = "";
+    viewVals.view_name = "";
+    _profiler->SetRumView(&viewVals);
 
     std::vector<RumViewRecord> records;
     _profiler->ConsumeViewRecords(records);
@@ -834,53 +885,62 @@ TEST_F(ProfilerRumContextTest, VitalsResetOnViewEnd) {
 }
 
 TEST_F(ProfilerRumContextTest, VitalsResetOnNewViewStart) {
-    RumContextValues ctx = {};
-    ctx.application_id = "app-1";
-    ctx.session_id = "session-1";
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-1";
+    sessionCtx.session_id = "session-1";
+    _profiler->SetRumSession(&sessionCtx);
+
+    RumViewValues viewVals = {};
 
     // Start view and accumulate vitals
-    ctx.view_id = "view-1";
-    ctx.view_name = "Page1";
-    _profiler->UpdateRumContext(&ctx);
+    viewVals.view_id = "view-1";
+    viewVals.view_name = "Page1";
+    _profiler->SetRumView(&viewVals);
     _profiler->AccumulateViewVitals(ViewVitalKind::WaitTime, 1000);
     _profiler->AccumulateViewVitals(ViewVitalKind::CpuTime, 2000);
 
     // Switch directly to a new view (without clearing)
-    ctx.view_id = "view-2";
-    ctx.view_name = "Page2";
-    _profiler->UpdateRumContext(&ctx);
+    viewVals.view_id = "view-2";
+    viewVals.view_name = "Page2";
+    _profiler->SetRumView(&viewVals);
 
     // Accumulate for the second view
     _profiler->AccumulateViewVitals(ViewVitalKind::WaitTime, 300);
     _profiler->AccumulateViewVitals(ViewVitalKind::CpuTime, 400);
 
-    ctx.view_id = "";
-    ctx.view_name = "";
-    _profiler->UpdateRumContext(&ctx);
+    viewVals.view_id = "";
+    viewVals.view_name = "";
+    _profiler->SetRumView(&viewVals);
 
     std::vector<RumViewRecord> records;
     _profiler->ConsumeViewRecords(records);
-    ASSERT_EQ(records.size(), 1u);
-    EXPECT_EQ(records[0].view_id, "view-2");
-    EXPECT_EQ(records[0].vitals_ns[static_cast<size_t>(ViewVitalKind::WaitTime)], 300);
-    EXPECT_EQ(records[0].vitals_ns[static_cast<size_t>(ViewVitalKind::CpuTime)], 400);
+    ASSERT_EQ(records.size(), 2u);
+    EXPECT_EQ(records[0].view_id, "view-1");
+    EXPECT_EQ(records[0].vitals_ns[static_cast<size_t>(ViewVitalKind::WaitTime)], 1000);
+    EXPECT_EQ(records[0].vitals_ns[static_cast<size_t>(ViewVitalKind::CpuTime)], 2000);
+    EXPECT_EQ(records[1].view_id, "view-2");
+    EXPECT_EQ(records[1].vitals_ns[static_cast<size_t>(ViewVitalKind::WaitTime)], 300);
+    EXPECT_EQ(records[1].vitals_ns[static_cast<size_t>(ViewVitalKind::CpuTime)], 400);
 }
 
 TEST_F(ProfilerRumContextTest, VitalsRejectOutOfRangeKind) {
-    RumContextValues ctx = {};
-    ctx.application_id = "app-1";
-    ctx.session_id = "session-1";
-    ctx.view_id = "view-1";
-    ctx.view_name = "Page1";
-    _profiler->UpdateRumContext(&ctx);
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-1";
+    sessionCtx.session_id = "session-1";
+    _profiler->SetRumSession(&sessionCtx);
+
+    RumViewValues viewVals = {};
+    viewVals.view_id = "view-1";
+    viewVals.view_name = "Page1";
+    _profiler->SetRumView(&viewVals);
 
     EXPECT_FALSE(_profiler->AccumulateViewVitals(ViewVitalKind::Unknown, 100));
     EXPECT_FALSE(_profiler->AccumulateViewVitals(static_cast<ViewVitalKind>(255), 100));
 
     // End view and verify nothing was accumulated from the rejected calls
-    ctx.view_id = "";
-    ctx.view_name = "";
-    _profiler->UpdateRumContext(&ctx);
+    viewVals.view_id = "";
+    viewVals.view_name = "";
+    _profiler->SetRumView(&viewVals);
 
     std::vector<RumViewRecord> records;
     _profiler->ConsumeViewRecords(records);
@@ -890,17 +950,20 @@ TEST_F(ProfilerRumContextTest, VitalsRejectOutOfRangeKind) {
 }
 
 TEST_F(ProfilerRumContextTest, VitalsZeroWhenNoAccumulation) {
-    RumContextValues ctx = {};
-    ctx.application_id = "app-1";
-    ctx.session_id = "session-1";
-    ctx.view_id = "view-1";
-    ctx.view_name = "Page1";
-    _profiler->UpdateRumContext(&ctx);
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-1";
+    sessionCtx.session_id = "session-1";
+    _profiler->SetRumSession(&sessionCtx);
+
+    RumViewValues viewVals = {};
+    viewVals.view_id = "view-1";
+    viewVals.view_name = "Page1";
+    _profiler->SetRumView(&viewVals);
 
     // End the view without any AccumulateViewVitals calls
-    ctx.view_id = "";
-    ctx.view_name = "";
-    _profiler->UpdateRumContext(&ctx);
+    viewVals.view_id = "";
+    viewVals.view_name = "";
+    _profiler->SetRumView(&viewVals);
 
     std::vector<RumViewRecord> records;
     _profiler->ConsumeViewRecords(records);
@@ -946,3 +1009,344 @@ TEST(RumRecordJsonTests, MultipleViewsWithDifferentVitals) {
 // payload passed to libdatadog through optional_internal_metadata_json. The
 // tests above (RumRecordJsonTests) therefore double-cover that payload's
 // shape; no dedicated internal-metadata suite is needed.
+
+// ---------------------------------------------------------------------------
+// ClearRumContext tests
+// ---------------------------------------------------------------------------
+
+TEST_F(ProfilerRumContextTest, ClearRumContextCompletesRecords) {
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-1";
+    sessionCtx.session_id = "S1";
+    _profiler->SetRumSession(&sessionCtx);
+
+    RumViewValues viewVals = {};
+    viewVals.view_id = "view-1";
+    viewVals.view_name = "Page1";
+    _profiler->SetRumView(&viewVals);
+
+    ::Sleep(50);
+
+    _profiler->ClearRumContext();
+
+    std::vector<RumViewRecord> viewRecords;
+    _profiler->ConsumeViewRecords(viewRecords);
+    ASSERT_EQ(viewRecords.size(), 1u);
+    EXPECT_EQ(viewRecords[0].view_id, "view-1");
+    EXPECT_GE(viewRecords[0].duration_ms, 40);
+
+    std::vector<RumSessionRecord> sessionRecords;
+    _profiler->ConsumeSessionRecords(sessionRecords);
+    ASSERT_EQ(sessionRecords.size(), 1u);
+    EXPECT_EQ(sessionRecords[0].session_id, "S1");
+
+    // Verify state is clean
+    RumViewContext viewCtx;
+    EXPECT_FALSE(_profiler->GetCurrentViewContext(viewCtx));
+    EXPECT_TRUE(_profiler->GetCurrentSessionId().empty());
+}
+
+TEST_F(ProfilerRumContextTest, ClearRumContextClearsAppId) {
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-1";
+    sessionCtx.session_id = "S1";
+    EXPECT_TRUE(_profiler->SetRumSession(&sessionCtx));
+
+    _profiler->ClearRumContext();
+
+    // After clearing, a different app_id should be accepted
+    RumSessionContext sessionCtx2 = {};
+    sessionCtx2.application_id = "app-2";
+    sessionCtx2.session_id = "S2";
+    EXPECT_TRUE(_profiler->SetRumSession(&sessionCtx2));
+}
+
+TEST_F(ProfilerRumContextTest, ClearRumContextAfterOnlySession) {
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-1";
+    sessionCtx.session_id = "S1";
+    _profiler->SetRumSession(&sessionCtx);
+
+    _profiler->ClearRumContext();
+
+    std::vector<RumSessionRecord> sessionRecords;
+    _profiler->ConsumeSessionRecords(sessionRecords);
+    ASSERT_EQ(sessionRecords.size(), 1u);
+    EXPECT_EQ(sessionRecords[0].session_id, "S1");
+
+    std::vector<RumViewRecord> viewRecords;
+    _profiler->ConsumeViewRecords(viewRecords);
+    EXPECT_TRUE(viewRecords.empty());
+}
+
+// ---------------------------------------------------------------------------
+// Consistency tests
+// ---------------------------------------------------------------------------
+
+TEST_F(ProfilerRumContextTest, SetRumViewWithoutSessionReturnsFalse) {
+    RumViewValues viewVals = {};
+    viewVals.view_id = "view-1";
+    viewVals.view_name = "Page1";
+    EXPECT_FALSE(_profiler->SetRumView(&viewVals));
+
+    RumViewContext viewCtx;
+    EXPECT_FALSE(_profiler->GetCurrentViewContext(viewCtx));
+}
+
+TEST_F(ProfilerRumContextTest, EnterViewWithoutSessionReturnsFalse) {
+    EXPECT_FALSE(_profiler->EnterView("Page1"));
+
+    RumViewContext viewCtx;
+    EXPECT_FALSE(_profiler->GetCurrentViewContext(viewCtx));
+}
+
+TEST_F(ProfilerRumContextTest, SetRumViewSucceedsAfterSession) {
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-1";
+    sessionCtx.session_id = "S1";
+    EXPECT_TRUE(_profiler->SetRumSession(&sessionCtx));
+
+    RumViewValues viewVals = {};
+    viewVals.view_id = "view-1";
+    viewVals.view_name = "Page1";
+    EXPECT_TRUE(_profiler->SetRumView(&viewVals));
+
+    RumViewContext viewCtx;
+    EXPECT_TRUE(_profiler->GetCurrentViewContext(viewCtx));
+    EXPECT_EQ(viewCtx.view_id, "view-1");
+}
+
+TEST_F(ProfilerRumContextTest, EnterViewSucceedsAfterSession) {
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-1";
+    sessionCtx.session_id = "S1";
+    EXPECT_TRUE(_profiler->SetRumSession(&sessionCtx));
+
+    EXPECT_TRUE(_profiler->EnterView("Page1"));
+
+    RumViewContext viewCtx;
+    EXPECT_TRUE(_profiler->GetCurrentViewContext(viewCtx));
+    EXPECT_FALSE(viewCtx.view_id.empty());
+    EXPECT_EQ(viewCtx.view_name, "Page1");
+}
+
+TEST_F(ProfilerRumContextTest, ViewUpdatesBetweenConsecutiveSetRumViewCalls) {
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-1";
+    sessionCtx.session_id = "S1";
+    _profiler->SetRumSession(&sessionCtx);
+
+    RumViewValues viewVals = {};
+    viewVals.view_id = "view-1";
+    viewVals.view_name = "Page1";
+    _profiler->SetRumView(&viewVals);
+
+    RumViewContext viewCtx;
+    EXPECT_TRUE(_profiler->GetCurrentViewContext(viewCtx));
+    EXPECT_EQ(viewCtx.view_id, "view-1");
+    EXPECT_EQ(viewCtx.view_name, "Page1");
+
+    viewVals.view_id = "view-2";
+    viewVals.view_name = "Page2";
+    _profiler->SetRumView(&viewVals);
+
+    EXPECT_TRUE(_profiler->GetCurrentViewContext(viewCtx));
+    EXPECT_EQ(viewCtx.view_id, "view-2");
+    EXPECT_EQ(viewCtx.view_name, "Page2");
+}
+
+TEST_F(ProfilerRumContextTest, ViewUpdatesBetweenConsecutiveEnterViewCalls) {
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-1";
+    sessionCtx.session_id = "S1";
+    _profiler->SetRumSession(&sessionCtx);
+
+    _profiler->EnterView("Page1");
+    RumViewContext viewCtx1;
+    EXPECT_TRUE(_profiler->GetCurrentViewContext(viewCtx1));
+    EXPECT_EQ(viewCtx1.view_name, "Page1");
+
+    _profiler->EnterView("Page2");
+    RumViewContext viewCtx2;
+    EXPECT_TRUE(_profiler->GetCurrentViewContext(viewCtx2));
+    EXPECT_EQ(viewCtx2.view_name, "Page2");
+    EXPECT_NE(viewCtx1.view_id, viewCtx2.view_id);
+}
+
+TEST_F(ProfilerRumContextTest, StackedSetRumViewCompletesFirstView) {
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-1";
+    sessionCtx.session_id = "S1";
+    _profiler->SetRumSession(&sessionCtx);
+
+    RumViewValues viewVals = {};
+    viewVals.view_id = "view-1";
+    viewVals.view_name = "Page1";
+    _profiler->SetRumView(&viewVals);
+    ::Sleep(50);
+
+    viewVals.view_id = "view-2";
+    viewVals.view_name = "Page2";
+    _profiler->SetRumView(&viewVals);
+    ::Sleep(50);
+
+    viewVals.view_id = "";
+    viewVals.view_name = "";
+    _profiler->SetRumView(&viewVals);
+
+    std::vector<RumViewRecord> records;
+    _profiler->ConsumeViewRecords(records);
+    ASSERT_EQ(records.size(), 2u);
+    EXPECT_EQ(records[0].view_id, "view-1");
+    EXPECT_EQ(records[0].view_name, "Page1");
+    EXPECT_GE(records[0].duration_ms, 40);
+    EXPECT_EQ(records[1].view_id, "view-2");
+    EXPECT_EQ(records[1].view_name, "Page2");
+    EXPECT_GE(records[1].duration_ms, 40);
+}
+
+TEST_F(ProfilerRumContextTest, StackedEnterViewCompletesFirstView) {
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-1";
+    sessionCtx.session_id = "S1";
+    _profiler->SetRumSession(&sessionCtx);
+
+    _profiler->EnterView("Page1");
+    ::Sleep(50);
+
+    _profiler->EnterView("Page2");
+    ::Sleep(50);
+
+    _profiler->LeaveCurrentView();
+
+    std::vector<RumViewRecord> records;
+    _profiler->ConsumeViewRecords(records);
+    ASSERT_EQ(records.size(), 2u);
+    EXPECT_EQ(records[0].view_name, "Page1");
+    EXPECT_GE(records[0].duration_ms, 40);
+    EXPECT_EQ(records[1].view_name, "Page2");
+    EXPECT_GE(records[1].duration_ms, 40);
+    EXPECT_NE(records[0].view_id, records[1].view_id);
+}
+
+TEST_F(ProfilerRumContextTest, SessionChangeDoesNotAffectActiveView) {
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-1";
+    sessionCtx.session_id = "S1";
+    _profiler->SetRumSession(&sessionCtx);
+
+    RumViewValues viewVals = {};
+    viewVals.view_id = "view-1";
+    viewVals.view_name = "Page1";
+    _profiler->SetRumView(&viewVals);
+
+    sessionCtx.session_id = "S2";
+    _profiler->SetRumSession(&sessionCtx);
+
+    RumViewContext viewCtx;
+    EXPECT_TRUE(_profiler->GetCurrentViewContext(viewCtx));
+    EXPECT_EQ(viewCtx.view_id, "view-1");
+    EXPECT_EQ(viewCtx.view_name, "Page1");
+}
+
+// ---------------------------------------------------------------------------
+// View lifecycle tests
+// ---------------------------------------------------------------------------
+
+TEST_F(ProfilerRumContextTest, ViewEndsWithNullViewId) {
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-1";
+    sessionCtx.session_id = "S1";
+    _profiler->SetRumSession(&sessionCtx);
+
+    RumViewValues viewVals = {};
+    viewVals.view_id = "view-1";
+    viewVals.view_name = "Page1";
+    _profiler->SetRumView(&viewVals);
+
+    viewVals.view_id = nullptr;
+    viewVals.view_name = nullptr;
+    EXPECT_TRUE(_profiler->SetRumView(&viewVals));
+
+    RumViewContext viewCtx;
+    EXPECT_FALSE(_profiler->GetCurrentViewContext(viewCtx));
+
+    std::vector<RumViewRecord> records;
+    _profiler->ConsumeViewRecords(records);
+    ASSERT_EQ(records.size(), 1u);
+    EXPECT_EQ(records[0].view_id, "view-1");
+}
+
+TEST_F(ProfilerRumContextTest, ViewEndsWithEmptyViewId) {
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-1";
+    sessionCtx.session_id = "S1";
+    _profiler->SetRumSession(&sessionCtx);
+
+    RumViewValues viewVals = {};
+    viewVals.view_id = "view-1";
+    viewVals.view_name = "Page1";
+    _profiler->SetRumView(&viewVals);
+
+    viewVals.view_id = "";
+    viewVals.view_name = "";
+    EXPECT_TRUE(_profiler->SetRumView(&viewVals));
+
+    RumViewContext viewCtx;
+    EXPECT_FALSE(_profiler->GetCurrentViewContext(viewCtx));
+
+    std::vector<RumViewRecord> records;
+    _profiler->ConsumeViewRecords(records);
+    ASSERT_EQ(records.size(), 1u);
+    EXPECT_EQ(records[0].view_id, "view-1");
+}
+
+TEST_F(ProfilerRumContextTest, LeaveCurrentViewCompletesView) {
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-1";
+    sessionCtx.session_id = "S1";
+    _profiler->SetRumSession(&sessionCtx);
+
+    _profiler->EnterView("Page1");
+    ::Sleep(50);
+
+    EXPECT_TRUE(_profiler->LeaveCurrentView());
+
+    RumViewContext viewCtx;
+    EXPECT_FALSE(_profiler->GetCurrentViewContext(viewCtx));
+
+    std::vector<RumViewRecord> records;
+    _profiler->ConsumeViewRecords(records);
+    ASSERT_EQ(records.size(), 1u);
+    EXPECT_EQ(records[0].view_name, "Page1");
+    EXPECT_GE(records[0].duration_ms, 40);
+}
+
+TEST_F(ProfilerRumContextTest, LeaveCurrentViewWithNoViewReturnsFalse) {
+    EXPECT_FALSE(_profiler->LeaveCurrentView());
+}
+
+TEST_F(ProfilerRumContextTest, SetRumViewAfterClearRumContextReturnsFalse) {
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-1";
+    sessionCtx.session_id = "S1";
+    _profiler->SetRumSession(&sessionCtx);
+
+    _profiler->ClearRumContext();
+
+    RumViewValues viewVals = {};
+    viewVals.view_id = "view-1";
+    viewVals.view_name = "Page1";
+    EXPECT_FALSE(_profiler->SetRumView(&viewVals));
+}
+
+TEST_F(ProfilerRumContextTest, EnterViewAfterClearRumContextReturnsFalse) {
+    RumSessionContext sessionCtx = {};
+    sessionCtx.application_id = "app-1";
+    sessionCtx.session_id = "S1";
+    _profiler->SetRumSession(&sessionCtx);
+
+    _profiler->ClearRumContext();
+
+    EXPECT_FALSE(_profiler->EnterView("Page1"));
+}

--- a/src/dd-win-prof/Configuration.cpp
+++ b/src/dd-win-prof/Configuration.cpp
@@ -587,7 +587,7 @@ T Configuration::GetEnvironmentValue(char const* name, T const& defaultValue)
     return result;
 }
 
-bool InitializeConfiguration(Configuration* pConfig, ProfilerConfig* pSettings)
+bool InitializeConfiguration(Configuration* pConfig, const ProfilerConfig* pSettings)
 {
     // if noEnvVars is set, we ignore all environment variables and use only the values provided in the ProfilerConfig struct (or defaults if not set in the struct)
     if (pSettings->noEnvVars)

--- a/src/dd-win-prof/Profiler.cpp
+++ b/src/dd-win-prof/Profiler.cpp
@@ -8,6 +8,8 @@
 #include "SampleValueTypeProvider.h"
 #include "SamplesCollector.h"
 
+#include <random>
+
 Profiler* Profiler::_this = nullptr;
 std::unique_ptr<Configuration> Profiler::_pConfiguration = std::make_unique<Configuration>();
 
@@ -69,7 +71,7 @@ bool Profiler::StartProfiling()
     // Flush buffered RUM application ID to the exporter
     {
         std::lock_guard lock(_rumAppMutex);
-        if (_rumAppIdSet)
+        if (!_rumApplicationId.empty())
         {
             _pProfileExporter->SetRumApplicationId(_rumApplicationId);
         }
@@ -155,9 +157,56 @@ void Profiler::RemoveCurrentThread()
     _pThreadList->RemoveThread(tid);
 }
 
-bool Profiler::UpdateRumContext(const RumContextValues* pContext)
+static std::string GenerateUuidV4()
 {
+    static thread_local std::mt19937 rng(std::random_device{}());
+    std::uniform_int_distribution<uint32_t> dist(0, 0xFFFFFFFF);
+
+    auto r = [&]() { return dist(rng); };
+    char buf[37];
+    std::snprintf(buf, sizeof(buf),
+        "%08x-%04x-%04x-%04x-%04x%08x",
+        r(),
+        r() & 0xFFFF,
+        (r() & 0x0FFF) | 0x4000,
+        (r() & 0x3FFF) | 0x8000,
+        r() & 0xFFFF, r());
+    return buf;
+}
+
+void Profiler::CompleteCurrentSession()
+{
+    if (_currentSessionId.empty())
+    {
+        return;
+    }
+
+    auto nowMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::system_clock::now().time_since_epoch()).count();
+    _completedSessionRecords.push_back({
+        _sessionStartMs,
+        nowMs - _sessionStartMs,
+        std::move(_currentSessionId)
+    });
+    _currentSessionId.clear();
+}
+
+bool Profiler::SetRumSession(const RumSessionContext* pContext)
+{
+    // sanity checks
     if (pContext == nullptr)
+    {
+        return false;
+    }
+
+    bool hasAppId = pContext->application_id != nullptr && pContext->application_id[0] != '\0';
+    if (!hasAppId)
+    {
+        return false;
+    }
+
+    bool hasSessionId = pContext->session_id != nullptr && pContext->session_id[0] != '\0';
+    if (!hasSessionId)
     {
         return false;
     }
@@ -165,98 +214,140 @@ bool Profiler::UpdateRumContext(const RumContextValues* pContext)
     // Application ID: write-once, buffered until exporter exists
     {
         std::lock_guard lock(_rumAppMutex);
-        bool hasAppId = pContext->application_id != nullptr && pContext->application_id[0] != '\0';
 
-        if (hasAppId)
+        // it is not allowed to change the application id
+        if (!_rumApplicationId.empty() && _rumApplicationId != pContext->application_id)
         {
-            if (_rumAppIdSet && _rumApplicationId != pContext->application_id)
-            {
-                return false;
-            }
+            return false;
+        }
 
-            if (!_rumAppIdSet)
-            {
-                _rumApplicationId = pContext->application_id;
-                _rumAppIdSet = true;
+        if (_rumApplicationId.empty())
+        {
+            _rumApplicationId = pContext->application_id;
 
-                if (_pProfileExporter != nullptr)
-                {
-                    _pProfileExporter->SetRumApplicationId(_rumApplicationId);
-                }
+            if (_pProfileExporter != nullptr)
+            {
+                _pProfileExporter->SetRumApplicationId(_rumApplicationId);
             }
         }
     }
 
-    // Session + view context: update under exclusive/writer lock
+
+    // Session tracking: complete previous session on change, start new one
     {
         std::unique_lock lock(_rumContextMutex);
 
-        // Session tracking: complete previous session on change, start new one
-        bool hasSessionId = pContext->session_id != nullptr && pContext->session_id[0] != '\0';
-        if (hasSessionId && _currentSessionId != pContext->session_id)
+        if (_currentSessionId != pContext->session_id)
         {
-            if (_hasPendingSession)
-            {
-                auto nowMs = std::chrono::duration_cast<std::chrono::milliseconds>(
-                    std::chrono::system_clock::now().time_since_epoch()).count();
-                _completedSessionRecords.push_back({
-                    _sessionStartMs,
-                    nowMs - _sessionStartMs,
-                    std::move(_currentSessionId)
-                });
-            }
+            CompleteCurrentSession();
 
             _currentSessionId = pContext->session_id;
             _sessionStartMs = std::chrono::duration_cast<std::chrono::milliseconds>(
                 std::chrono::system_clock::now().time_since_epoch()).count();
-            _hasPendingSession = true;
-        }
-
-        // View tracking
-        if (pContext->view_id != nullptr && pContext->view_id[0] != '\0')
-        {
-            _currentRumView.view_id = pContext->view_id;
-            _currentRumView.view_name = (pContext->view_name != nullptr) ? pContext->view_name : "";
-            _hasActiveView = true;
-
-            _pendingViewStartMs = std::chrono::duration_cast<std::chrono::milliseconds>(
-                std::chrono::system_clock::now().time_since_epoch()).count();
-            _hasPendingView = true;
-
-            for (auto& a : _pendingVitalsNs)
-                a.store(0, std::memory_order_relaxed);
-        }
-        else
-        {
-            if (_hasPendingView)
-            {
-                auto nowMs = std::chrono::duration_cast<std::chrono::milliseconds>(
-                    std::chrono::system_clock::now().time_since_epoch()).count();
-
-                RumViewRecord rec;
-                rec.timestamp_ms = _pendingViewStartMs;
-                rec.duration_ms  = nowMs - _pendingViewStartMs;
-                rec.view_id      = std::move(_currentRumView.view_id);
-                rec.view_name    = std::move(_currentRumView.view_name);
-                for (size_t i = 0; i < MaxViewVitalKind; ++i)
-                    rec.vitals_ns[i] = _pendingVitalsNs[i].exchange(0, std::memory_order_relaxed);
-                _completedViewRecords.push_back(std::move(rec));
-                _hasPendingView = false;
-            }
-
-            _currentRumView.view_id.clear();
-            _currentRumView.view_name.clear();
-            _hasActiveView = false;
         }
     }
 
     return true;
 }
 
+void Profiler::CompleteCurrentView()
+{
+    if (_currentRumView.view_id.empty())
+    {
+        return;
+    }
+
+    auto nowMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::system_clock::now().time_since_epoch()).count();
+
+    RumViewRecord rec;
+    rec.timestamp_ms = _pendingViewStartMs;
+    rec.duration_ms  = nowMs - _pendingViewStartMs;
+    rec.view_id      = std::move(_currentRumView.view_id);
+    rec.view_name    = std::move(_currentRumView.view_name);
+    for (size_t i = 0; i < MaxViewVitalKind; ++i)
+        rec.vitals_ns[i] = _pendingVitalsNs[i].exchange(0, std::memory_order_relaxed);
+    _completedViewRecords.push_back(std::move(rec));
+
+    _currentRumView.view_id.clear();
+    _currentRumView.view_name.clear();
+}
+
+bool Profiler::SetRumView(const RumViewValues* pContext)
+{
+    std::unique_lock lock(_rumContextMutex);
+
+    if (_currentSessionId.empty())
+    {
+        return false;
+    }
+
+    CompleteCurrentView();
+
+    bool hasViewId = pContext != nullptr
+                  && pContext->view_id != nullptr
+                  && pContext->view_id[0] != '\0';
+
+    if (!hasViewId)
+    {
+        return true;
+    }
+
+    _currentRumView.view_id = pContext->view_id;
+    _currentRumView.view_name = (pContext->view_name != nullptr) ? pContext->view_name : "";
+
+    _pendingViewStartMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::system_clock::now().time_since_epoch()).count();
+
+    for (auto& a : _pendingVitalsNs)
+        a.store(0, std::memory_order_relaxed);
+
+    return true;
+}
+
+void Profiler::ClearRumContext()
+{
+    // Clear session and view state
+    {
+        std::unique_lock lock(_rumContextMutex);
+
+        CompleteCurrentSession();
+        CompleteCurrentView();
+    }
+
+    // Clear the application ID
+    {
+        std::lock_guard lock(_rumAppMutex);
+        _rumApplicationId.clear();
+    }
+}
+
+bool Profiler::EnterView(const char* viewName)
+{
+    std::string viewId = GenerateUuidV4();
+    RumViewValues vals = {};
+    vals.view_id = viewId.c_str();
+    vals.view_name = viewName;
+    return SetRumView(&vals);
+}
+
+bool Profiler::LeaveCurrentView()
+{
+    std::unique_lock lock(_rumContextMutex);
+
+    if (_currentRumView.view_id.empty())
+    {
+        return false;
+    }
+
+    CompleteCurrentView();
+    return true;
+}
+
 bool Profiler::GetCurrentViewContext(RumViewContext& context) const
 {
     std::shared_lock lock(_rumContextMutex);
-    if (!_hasActiveView)
+    if (_currentRumView.view_id.empty())
     {
         return false;
     }

--- a/src/dd-win-prof/Profiler.cpp
+++ b/src/dd-win-prof/Profiler.cpp
@@ -193,10 +193,12 @@ void Profiler::CompleteCurrentSession()
 
 bool Profiler::SetRumSession(const RumSessionContext* pContext)
 {
-    // sanity checks
     if (pContext == nullptr)
     {
-        return false;
+        std::unique_lock lock(_rumContextMutex);
+        CompleteCurrentSession();
+        CompleteCurrentView();
+        return true;
     }
 
     bool hasAppId = pContext->application_id != nullptr && pContext->application_id[0] != '\0';
@@ -295,15 +297,6 @@ bool Profiler::SetRumView(const RumViewValues* pContext)
         a.store(0, std::memory_order_relaxed);
 
     return true;
-}
-
-void Profiler::ClearRumContext()
-{
-    std::unique_lock lock(_rumContextMutex);
-
-    CompleteCurrentSession();
-    CompleteCurrentView();
-    _rumApplicationId.clear();
 }
 
 bool Profiler::EnterView(const char* viewName)

--- a/src/dd-win-prof/Profiler.cpp
+++ b/src/dd-win-prof/Profiler.cpp
@@ -70,7 +70,7 @@ bool Profiler::StartProfiling()
 
     // Flush buffered RUM application ID to the exporter
     {
-        std::lock_guard lock(_rumAppMutex);
+        std::shared_lock lock(_rumContextMutex);
         if (!_rumApplicationId.empty())
         {
             _pProfileExporter->SetRumApplicationId(_rumApplicationId);
@@ -211,40 +211,32 @@ bool Profiler::SetRumSession(const RumSessionContext* pContext)
         return false;
     }
 
+    std::unique_lock lock(_rumContextMutex);
+
     // Application ID: write-once, buffered until exporter exists
+    if (!_rumApplicationId.empty() && _rumApplicationId != pContext->application_id)
     {
-        std::lock_guard lock(_rumAppMutex);
+        return false;
+    }
 
-        // it is not allowed to change the application id
-        if (!_rumApplicationId.empty() && _rumApplicationId != pContext->application_id)
+    if (_rumApplicationId.empty())
+    {
+        _rumApplicationId = pContext->application_id;
+
+        if (_pProfileExporter != nullptr)
         {
-            return false;
-        }
-
-        if (_rumApplicationId.empty())
-        {
-            _rumApplicationId = pContext->application_id;
-
-            if (_pProfileExporter != nullptr)
-            {
-                _pProfileExporter->SetRumApplicationId(_rumApplicationId);
-            }
+            _pProfileExporter->SetRumApplicationId(_rumApplicationId);
         }
     }
 
-
     // Session tracking: complete previous session on change, start new one
+    if (_currentSessionId != pContext->session_id)
     {
-        std::unique_lock lock(_rumContextMutex);
+        CompleteCurrentSession();
 
-        if (_currentSessionId != pContext->session_id)
-        {
-            CompleteCurrentSession();
-
-            _currentSessionId = pContext->session_id;
-            _sessionStartMs = std::chrono::duration_cast<std::chrono::milliseconds>(
-                std::chrono::system_clock::now().time_since_epoch()).count();
-        }
+        _currentSessionId = pContext->session_id;
+        _sessionStartMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
     }
 
     return true;
@@ -307,19 +299,11 @@ bool Profiler::SetRumView(const RumViewValues* pContext)
 
 void Profiler::ClearRumContext()
 {
-    // Clear session and view state
-    {
-        std::unique_lock lock(_rumContextMutex);
+    std::unique_lock lock(_rumContextMutex);
 
-        CompleteCurrentSession();
-        CompleteCurrentView();
-    }
-
-    // Clear the application ID
-    {
-        std::lock_guard lock(_rumAppMutex);
-        _rumApplicationId.clear();
-    }
+    CompleteCurrentSession();
+    CompleteCurrentView();
+    _rumApplicationId.clear();
 }
 
 bool Profiler::EnterView(const char* viewName)

--- a/src/dd-win-prof/Profiler.h
+++ b/src/dd-win-prof/Profiler.h
@@ -37,7 +37,6 @@ public :
     bool LeaveCurrentView();
     bool SetRumSession(const RumSessionContext* pContext);
     bool SetRumView(const RumViewValues* pContext);
-    void ClearRumContext();
 
     // IRumViewContextProvider implementation
     bool GetCurrentViewContext(RumViewContext& context) const override;

--- a/src/dd-win-prof/Profiler.h
+++ b/src/dd-win-prof/Profiler.h
@@ -28,7 +28,7 @@ public :
     bool AddCurrentThread();
     void RemoveCurrentThread();
 
-    bool IsStarted() const { return _isStarted; }
+    bool IsStarted() const { return _isStarted.load(std::memory_order_relaxed); }
     size_t GetThreadCount() const { return _pThreadList ? _pThreadList->Count() : 0; }
     bool IsAutoStartEnabled() const { return _pConfiguration->IsProfilerAutoStartEnabled(); }
 
@@ -78,7 +78,7 @@ private:
     static Profiler* _this;
     static std::unique_ptr<Configuration> _pConfiguration;
 
-    bool _isStarted;
+    std::atomic<bool> _isStarted;
 
     std::unique_ptr<ThreadList> _pThreadList;
     std::unique_ptr<StackSamplerLoop> _pStackSamplerLoop;
@@ -114,8 +114,7 @@ private:
     int64_t _sessionStartMs{0};
     std::vector<RumSessionRecord> _completedSessionRecords;
 
-    // RUM app-level ID (write-once, buffered until exporter exists)
-    std::mutex _rumAppMutex;
+    // RUM app-level ID (write-once, buffered until exporter exists; protected by _rumContextMutex)
     std::string _rumApplicationId;
 };
 

--- a/src/dd-win-prof/Profiler.h
+++ b/src/dd-win-prof/Profiler.h
@@ -8,6 +8,7 @@
 #include "Configuration.h"
 #include "CpuTimeProvider.h"
 #include "dd-win-prof.h"
+#include "dd-win-rum-private.h"
 #include "ProfileExporter.h"
 #include "RumContext.h"
 #include "SamplesCollector.h"
@@ -32,7 +33,11 @@ public :
     bool IsAutoStartEnabled() const { return _pConfiguration->IsProfilerAutoStartEnabled(); }
 
     // RUM context management (called from the C API, thread-safe)
-    bool UpdateRumContext(const RumContextValues* pContext);
+    bool EnterView(const char* viewName);
+    bool LeaveCurrentView();
+    bool SetRumSession(const RumSessionContext* pContext);
+    bool SetRumView(const RumViewValues* pContext);
+    void ClearRumContext();
 
     // IRumViewContextProvider implementation
     bool GetCurrentViewContext(RumViewContext& context) const override;
@@ -90,13 +95,14 @@ private:
 
     // RUM view + session context (dynamic, protected by reader/writer lock)
     mutable std::shared_mutex _rumContextMutex;
-    bool _hasActiveView{false};
     RumViewContext _currentRumView;
+
+    void CompleteCurrentView();     // caller must hold _rumContextMutex exclusive
+    void CompleteCurrentSession();  // caller must hold _rumContextMutex exclusive
 
     // RUM view timeline recording (protected by _rumContextMutex)
     std::vector<RumViewRecord> _completedViewRecords;
     int64_t _pendingViewStartMs{0};
-    bool _hasPendingView{false};
 
     // Per-view vitals accumulators indexed by ViewVitalKind.
     // Written lock-free from the sampler thread (fetch_add with relaxed ordering),
@@ -106,12 +112,10 @@ private:
     // RUM session tracking (protected by _rumContextMutex)
     std::string _currentSessionId;
     int64_t _sessionStartMs{0};
-    bool _hasPendingSession{false};
     std::vector<RumSessionRecord> _completedSessionRecords;
 
     // RUM app-level ID (write-once, buffered until exporter exists)
     std::mutex _rumAppMutex;
-    bool _rumAppIdSet{false};
     std::string _rumApplicationId;
 };
 

--- a/src/dd-win-prof/dd-win-prof-internal.h
+++ b/src/dd-win-prof/dd-win-prof-internal.h
@@ -10,4 +10,4 @@
 // When pSettings->noEnvVars is true, resets to defaults first so that
 // only the explicit struct fields take effect.
 // Returns false if mandatory fields are missing (url, apiKey when noEnvVars).
-bool InitializeConfiguration(Configuration* pConfig, ProfilerConfig* pSettings);
+bool InitializeConfiguration(Configuration* pConfig, const ProfilerConfig* pSettings);

--- a/src/dd-win-prof/dd-win-prof.cpp
+++ b/src/dd-win-prof/dd-win-prof.cpp
@@ -115,14 +115,4 @@ DD_WIN_PROF_API bool SetRumView(const RumViewValues* pContext)
     return profiler->SetRumView(pContext);
 }
 
-DD_WIN_PROF_API void ClearRumContext()
-{
-    auto profiler = Profiler::GetInstance();
-    if (profiler == nullptr)
-    {
-        return;
-    }
-    profiler->ClearRumContext();
-}
-
 }

--- a/src/dd-win-prof/dd-win-prof.cpp
+++ b/src/dd-win-prof/dd-win-prof.cpp
@@ -3,12 +3,13 @@
 
 #include "pch.h"
 #include "dd-win-prof-internal.h"
+#include "dd-win-rum-private.h"
 #include "Log.h"
 #include "Profiler.h"
 
 extern "C" {
 
-DD_WIN_PROF_API bool SetupProfiler(ProfilerConfig* pSettings)
+DD_WIN_PROF_API bool SetupProfiler(const ProfilerConfig* pSettings)
 {
     if (pSettings == nullptr)
     {
@@ -74,14 +75,54 @@ DD_WIN_PROF_API void StopProfiler()
     profiler->StopProfiling();
 }
 
-DD_WIN_PROF_API bool UpdateRumContext(const RumContextValues* pContext)
+DD_WIN_PROF_API bool EnterView(const char* viewName)
 {
     auto profiler = Profiler::GetInstance();
     if (profiler == nullptr)
     {
         return false;
     }
-    return profiler->UpdateRumContext(pContext);
+    return profiler->EnterView(viewName);
+}
+
+DD_WIN_PROF_API bool LeaveCurrentView()
+{
+    auto profiler = Profiler::GetInstance();
+    if (profiler == nullptr)
+    {
+        return false;
+    }
+    return profiler->LeaveCurrentView();
+}
+
+DD_WIN_PROF_API bool SetRumSession(const RumSessionContext* pContext)
+{
+    auto profiler = Profiler::GetInstance();
+    if (profiler == nullptr)
+    {
+        return false;
+    }
+    return profiler->SetRumSession(pContext);
+}
+
+DD_WIN_PROF_API bool SetRumView(const RumViewValues* pContext)
+{
+    auto profiler = Profiler::GetInstance();
+    if (profiler == nullptr)
+    {
+        return false;
+    }
+    return profiler->SetRumView(pContext);
+}
+
+DD_WIN_PROF_API void ClearRumContext()
+{
+    auto profiler = Profiler::GetInstance();
+    if (profiler == nullptr)
+    {
+        return;
+    }
+    profiler->ClearRumContext();
 }
 
 }

--- a/src/dd-win-prof/dd-win-prof.h
+++ b/src/dd-win-prof/dd-win-prof.h
@@ -46,33 +46,25 @@ typedef struct _ProfilerConfig
 } ProfilerConfig;
 
 
-// RUM (Real User Monitoring) context values.
-// Passed by dd-sdk-cpp to correlate profiling data with user sessions/views.
-typedef struct _RumContextValues
-{
-    const char* application_id;  // UUID string, set once per process lifetime
-    const char* session_id;      // UUID string, can change on session rotation
-    const char* view_id;         // nullptr or "" to clear current view
-    const char* view_name;       // human-readable name, e.g. "HomePage"
-} RumContextValues;
-
 extern "C" {
-    DD_WIN_PROF_API bool SetupProfiler(ProfilerConfig* pSettings);
+    DD_WIN_PROF_API bool SetupProfiler(const ProfilerConfig* pSettings);
+
     // Start profiling manually (returns false if already started or explicitly disabled)
     DD_WIN_PROF_API bool StartProfiler();
 
     // Stop profiling manually (safe to call even if not started)
     DD_WIN_PROF_API void StopProfiler();
 
-    // Update RUM context. Safe to call from any thread.
-    // On first call with non-empty application_id, stores it as a profile-level tag
-    // (subsequent calls with a different application_id are rejected).
-    // On every call with non-empty session_id, updates the current session. Session
-    // transitions are tracked with timestamps; the profile-level rum.session_id tag
-    // lists all session_ids since the last export.
-    // On every call, updates the view-level context (view_id/view_name).
-    // Pass nullptr/empty view_id to clear the current view (signals "between views").
-    DD_WIN_PROF_API bool UpdateRumContext(const RumContextValues* pContext);
+    // Enter a named view. Generates a unique view_id internally.
+    // Updates per-sample pprof labels: rum.view_id and trace endpoint (viewName).
+    // If a view is already active, it is completed first (record produced).
+    // Returns false if no session is active (a view requires an app+session).
+    DD_WIN_PROF_API bool EnterView(const char* viewName);
+
+    // Leave the current view (signals "between views").
+    // Completes the active view record. No-op if no view is active.
+    // Returns true if a view was active and is now cleared, false if no view was active.
+    DD_WIN_PROF_API bool LeaveCurrentView();
 
     // Environment Variables (independent controls):
     // DD_PROFILING_ENABLED: Controls whether profiler CAN be started

--- a/src/dd-win-prof/dd-win-rum-private.h
+++ b/src/dd-win-prof/dd-win-rum-private.h
@@ -1,0 +1,38 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2025 Datadog, Inc.
+
+#pragma once
+
+#include "dd-win-prof.h"
+
+typedef struct _RumSessionContext
+{
+    const char* application_id;  // UUID string, set once per process lifetime
+    const char* session_id;      // UUID string, changes on session rotation
+} RumSessionContext;
+
+typedef struct _RumViewValues
+{
+    const char* view_id;   // UUID string; nullptr or "" to clear current view
+    const char* view_name; // human-readable name, e.g. "HomePage"
+} RumViewValues;
+
+extern "C" {
+    // Set stable RUM session context. Safe to call from any thread.
+    // application_id: write-once per process. First non-empty value is stored
+    // as a profile-level tag; subsequent calls with a different value return false.
+    // session_id: updated on every call. Session transitions are tracked with
+    // timestamps.
+    // Returns false if pContext is null, application_id or session_id is missing,
+    // or a different application_id is rejected.
+    DD_WIN_PROF_API bool SetRumSession(const RumSessionContext* pContext);
+
+    // Set volatile RUM view context with explicit view_id. Safe to call from any thread.
+    // Pass nullptr/empty view_id to clear the current view (signals "between views").
+    // Returns false if no session is active.
+    DD_WIN_PROF_API bool SetRumView(const RumViewValues* pContext);
+
+    // Clear all RUM context (both session and view). Call on session end.
+    // Completes any pending session and view records before clearing.
+    DD_WIN_PROF_API void ClearRumContext();
+}

--- a/src/dd-win-prof/dd-win-rum-private.h
+++ b/src/dd-win-prof/dd-win-rum-private.h
@@ -23,7 +23,9 @@ extern "C" {
     // as a profile-level tag; subsequent calls with a different value return false.
     // session_id: updated on every call. Session transitions are tracked with
     // timestamps.
-    // Returns false if pContext is null, application_id or session_id is missing,
+    // Pass nullptr to end the current session: completes any pending session
+    // and view records, then returns true.
+    // Returns false if application_id or session_id is missing/empty,
     // or a different application_id is rejected.
     DD_WIN_PROF_API bool SetRumSession(const RumSessionContext* pContext);
 
@@ -31,8 +33,4 @@ extern "C" {
     // Pass nullptr/empty view_id to clear the current view (signals "between views").
     // Returns false if no session is active.
     DD_WIN_PROF_API bool SetRumView(const RumViewValues* pContext);
-
-    // Clear all RUM context (both session and view). Call on session end.
-    // Completes any pending session and view records before clearing.
-    DD_WIN_PROF_API void ClearRumContext();
 }

--- a/src/integration-tests/test_rum_scenario.ps1
+++ b/src/integration-tests/test_rum_scenario.ps1
@@ -16,12 +16,14 @@
 #   .\test_rum_scenario.ps1
 #   .\test_rum_scenario.ps1 -Config Release
 #   .\test_rum_scenario.ps1 -Iterations 3
+#   .\test_rum_scenario.ps1 -KeepArtifacts
 
 [CmdletBinding()]
 param(
     [ValidateSet("Debug", "Release", "Auto")]
     [string]$Config = "Auto",
-    [int]$Iterations = 3
+    [int]$Iterations = 3,
+    [switch]$KeepArtifacts
 )
 
 $ErrorActionPreference = "Stop"
@@ -156,7 +158,7 @@ foreach ($jsonFile in $jsonFiles) {
     }
 }
 
-$expectedViewCount = 3 * $Iterations
+$expectedViewCount = 4 * $Iterations
 Assert ($allViewEntries.Count -eq $expectedViewCount) `
     "Total view entries = $expectedViewCount ($($allViewEntries.Count) found)"
 
@@ -222,10 +224,17 @@ foreach ($s2 in $s2Records) {
 
 $failCount = Show-TestSummary
 
-try {
-    Remove-Item -Recurse -Force $testRoot -ErrorAction SilentlyContinue
-} catch {
-    Write-Host "  WARN: Could not clean up $testRoot" -ForegroundColor Yellow
+if ($KeepArtifacts) {
+    Write-Host ""
+    Write-Host "Artifacts kept at:" -ForegroundColor Cyan
+    Write-Host "  Pprof : $pprofDir" -ForegroundColor Gray
+    Write-Host "  Logs  : $logDir"   -ForegroundColor Gray
+} else {
+    try {
+        Remove-Item -Recurse -Force $testRoot -ErrorAction SilentlyContinue
+    } catch {
+        Write-Host "  WARN: Could not clean up $testRoot" -ForegroundColor Yellow
+    }
 }
 
 exit $failCount


### PR DESCRIPTION
## Description
Public API (dd-win-prof.h):
  - EnterView(const char* viewName): generates UUID, sets view context
  - LeaveCurrentView(): completes the active view record

Private/SDK API (dd-win-rum-private.h, new file):
  - SetRumSession(const RumSessionContext*): app ID (write-once) + session
  - SetRumView(const RumViewValues*): explicit view_id control
  - ClearRumContext(): completes and clears all RUM state

Key design decisions:
  - SetRumView requires an active session (returns false otherwise)
  - Setting a new view auto-completes the previous one (stacked views)
  - Redundant state flags (_rumAppIdSet, _hasActiveView, _hasPendingView, _hasPendingSession) removed in favour of checking the string fields
  - View/session completion logic extracted into CompleteCurrentView() and CompleteCurrentSession() helpers
  - const ProfilerConfig* applied to SetupProfiler and InitializeConfiguration

## Motivation
Inspired by PR #35, split the monolithic UpdateRumContext(RumContextValues*) into a layered API that separates stable session context from volatile view context.

## Testing
- [x] Built successfully on Windows
- [x] Existing tests pass
- [x] New tests added (if applicable)
- [x] Manually tested
Tests: 48 RUM context tests (23 updated + 25 new), 147 total pass.
Made-with: Cursor

## Checklist
- [x] Code follows existing style
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented) 