### PR TITLE
Runner: auto-generate session id; read RUM ids from env

### DIFF
--- a/src/Runner/CMakeLists.txt
+++ b/src/Runner/CMakeLists.txt
@@ -4,6 +4,8 @@ add_executable(Runner
     Spinner.cpp
     Helpers.h
     Spinner.h
+    ../dd-win-prof/Uuid.cpp
+    ../dd-win-prof/Uuid.h
 )
 
 target_link_libraries(Runner PRIVATE dd-win-prof)

--- a/src/Runner/Runner.cpp
+++ b/src/Runner/Runner.cpp
@@ -12,6 +12,9 @@
 #include <random>
 #include <string>
 
+// Uuid.cpp is compiled directly into Runner (see CMakeLists.txt) since
+// dd-win-prof.dll doesn't export the symbol.
+#include "..\dd-win-prof\Uuid.h"
 #include "..\dd-win-prof\dd-win-rum-private.h"
 #include "Helpers.h"
 #include "Spinner.h"
@@ -570,8 +573,11 @@ void ShowHelp(const char* programName) {
 
   std::cout << "RUM Context Options (scenario 5):\n";
   std::cout
-      << "  --rum-app-id <uuid>    RUM application ID (required for scenario 5)\n";
-  std::cout << "  --rum-session-id <uuid> RUM session ID (required for scenario 5)\n\n";
+      << "  --rum-app-id <uuid>    RUM application ID (required for scenario 5;\n"
+         "                           falls back to DD_RUM_APPLICATION_ID env var)\n";
+  std::cout << "  --rum-session-id <uuid> RUM session ID (optional; falls back to\n"
+               "                           DD_RUM_SESSION_ID env var, else "
+               "auto-generated)\n\n";
 
   std::cout << "Additional Options:\n";
   std::cout << "  --symbolize            Enable call stack symbolization (default: "
@@ -757,12 +763,27 @@ bool ParseCommandLine(int argc, char* argv[], RunnerOptions& opts) {
 
   if (opts.scenario == 5) {
     if (opts.rumApplicationId.empty()) {
-      std::cout << "Error: --rum-app-id is mandatory for scenario 5.\n";
+      char buf[128] = {};
+      if (::GetEnvironmentVariableA("DD_RUM_APPLICATION_ID", buf, sizeof(buf)) > 0) {
+        opts.rumApplicationId = buf;
+      }
+    }
+    if (opts.rumApplicationId.empty()) {
+      std::cout << "Error: --rum-app-id (or DD_RUM_APPLICATION_ID) is mandatory "
+                   "for scenario 5.\n";
       return false;
     }
+
     if (opts.rumSessionId.empty()) {
-      std::cout << "Error: --rum-session-id is mandatory for scenario 5.\n";
-      return false;
+      char buf[128] = {};
+      if (::GetEnvironmentVariableA("DD_RUM_SESSION_ID", buf, sizeof(buf)) > 0) {
+        opts.rumSessionId = buf;
+      }
+    }
+    if (opts.rumSessionId.empty()) {
+      opts.rumSessionId = ddprof::Uuid().to_string();
+      std::cout << "No --rum-session-id provided; auto-generated: " << opts.rumSessionId
+                << "\n";
     }
   }
 


### PR DESCRIPTION
## Summary
- Scenario 5 was painful to drive interactively: it required passing both `--rum-app-id` and `--rum-session-id` UUIDs on the command line every time, putting identifiers in shell history and adding friction for overhead measurement.
- `--rum-app-id` now falls back to `$DD_RUM_APPLICATION_ID` (still mandatory if neither is set — we want the profile correlatable with a known app).
- `--rum-session-id` falls back to `$DD_RUM_SESSION_ID`; if neither is set the runner generates a v4 UUID via `ddprof::Uuid` and prints it so the value is visible in the runner's output.
- `Uuid.cpp`/`Uuid.h` are compiled directly into the Runner target since the symbol isn't exported from `dd-win-prof.dll` — same workaround `Tests` already uses.

Note: the second session id used in scenario 5's session-rotation step is still the hardcoded `99999999-...` constant in `RunRumScenario`, since `test_rum_scenario.ps1` asserts on that exact value. With this change, a typical scenario 5 run produces two sessions (one auto-gen'd, one fixed), which exercises the multi-value-tag path nicely once the rum-session-id-tag PR lands on top of this one.

## Test plan
- [x] `Runner.exe --scenario 5 --iterations 1 --noenvvars --url ... --apikey ... --rum-app-id <uuid>` (no `--rum-session-id`) → runner prints "auto-generated: <uuid>" and exits cleanly
- [x] `$env:DD_RUM_APPLICATION_ID = "<uuid>"; Runner.exe --scenario 5 ... --rum-session-id <uuid>` → runner picks up the env app id silently
- [x] `pwsh src/integration-tests/test_rum_scenario.ps1 -Config Release` still passes (existing test passes both `--rum-app-id` and `--rum-session-id` explicitly, so the new fallback paths are bypassed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)