### PR TITLE
Emit rum.session_id as multi-value tags, capped at 10

### DIFF
--- a/src/Tests/ProfileExporterTests.cpp
+++ b/src/Tests/ProfileExporterTests.cpp
@@ -320,3 +320,60 @@ TEST_F(ProfileExporterExportTests, ExporterInitializesWithDefaultsAndExportEnabl
   // Explicit cleanup before destruction to avoid potential deadlocks
   exp->Cleanup();
 }
+
+// BuildRumTags is the tag-construction step extracted out of PrepareAdditionalTags
+// for testability (ddog_Tag is opaque, so we can't read entries back out of the
+// resulting ddog_Vec_Tag and have to pin the contract upstream of the push).
+
+TEST(ProfileExporterBuildRumTags, NoApplicationIdNoSessionsProducesEmptyList) {
+  auto tags = ProfileExporter::BuildRumTags("", {});
+  EXPECT_TRUE(tags.empty());
+}
+
+TEST(ProfileExporterBuildRumTags, ApplicationIdOnlyProducesSingleEntry) {
+  auto tags = ProfileExporter::BuildRumTags("app-uuid", {});
+  ASSERT_EQ(tags.size(), 1u);
+  EXPECT_EQ(tags[0].first, "rum.application_id");
+  EXPECT_EQ(tags[0].second, "app-uuid");
+}
+
+TEST(ProfileExporterBuildRumTags, SingleSessionEmitsOneSessionTag) {
+  auto tags = ProfileExporter::BuildRumTags("app-uuid", {"s1"});
+  ASSERT_EQ(tags.size(), 2u);
+  EXPECT_EQ(tags[0].first, "rum.application_id");
+  EXPECT_EQ(tags[0].second, "app-uuid");
+  EXPECT_EQ(tags[1].first, "rum.session_id");
+  EXPECT_EQ(tags[1].second, "s1");
+}
+
+TEST(ProfileExporterBuildRumTags, MultipleSessionsEmitOneEntryEach) {
+  auto tags = ProfileExporter::BuildRumTags("app-uuid", {"s1", "s2", "s3"});
+  ASSERT_EQ(tags.size(), 4u);
+  EXPECT_EQ(tags[0].first, "rum.application_id");
+  EXPECT_EQ(tags[0].second, "app-uuid");
+  // All three session entries reuse the same key and carry distinct values --
+  // this is the "repeated tag entries with the same key" multi-value shape.
+  EXPECT_EQ(tags[1].first, "rum.session_id");
+  EXPECT_EQ(tags[1].second, "s1");
+  EXPECT_EQ(tags[2].first, "rum.session_id");
+  EXPECT_EQ(tags[2].second, "s2");
+  EXPECT_EQ(tags[3].first, "rum.session_id");
+  EXPECT_EQ(tags[3].second, "s3");
+}
+
+TEST(ProfileExporterBuildRumTags, EmptyApplicationIdSuppressesAppEntryOnly) {
+  auto tags = ProfileExporter::BuildRumTags("", {"s1", "s2"});
+  ASSERT_EQ(tags.size(), 2u);
+  EXPECT_EQ(tags[0].first, "rum.session_id");
+  EXPECT_EQ(tags[0].second, "s1");
+  EXPECT_EQ(tags[1].first, "rum.session_id");
+  EXPECT_EQ(tags[1].second, "s2");
+}
+
+TEST(ProfileExporterBuildRumTags, EmptySessionIdsAreSkipped) {
+  auto tags = ProfileExporter::BuildRumTags("app-uuid", {"s1", "", "s2"});
+  ASSERT_EQ(tags.size(), 3u);
+  EXPECT_EQ(tags[0].first, "rum.application_id");
+  EXPECT_EQ(tags[1].second, "s1");
+  EXPECT_EQ(tags[2].second, "s2");
+}

--- a/src/dd-win-prof/ProfileExporter.cpp
+++ b/src/dd-win-prof/ProfileExporter.cpp
@@ -267,6 +267,7 @@ bool ProfileExporter::Export(bool lastCall) {
   // The same JSON is used for the local debug `.rum-views.json` file (if
   // enabled) and is passed to libdatadog via `optional_internal_metadata_json`.
   std::string rumRecordsJson;
+  std::vector<std::string> rumSessionIds;
   if (_pRumRecordProvider != nullptr) {
     _pRumRecordProvider->ConsumeViewRecords(_viewRecordsBuffer);
     _pRumRecordProvider->ConsumeSessionRecords(_sessionRecordsBuffer);
@@ -274,9 +275,42 @@ bool ProfileExporter::Export(bool lastCall) {
     if (!_viewRecordsBuffer.empty() || !_sessionRecordsBuffer.empty()) {
       rumRecordsJson =
           SerializeRumRecordsToJson(_viewRecordsBuffer, _sessionRecordsBuffer);
-      _viewRecordsBuffer.clear();
-      _sessionRecordsBuffer.clear();
     }
+
+    // Mirror the session ids that feed optional_internal_metadata_json into a
+    // separate vector so they can also be emitted as multi-value rum.session_id
+    // tags. Profiler::CompleteCurrentSession produces at most one record per
+    // session, so the list is already unique by construction.
+    //
+    // Capped at MAX_RUM_SESSION_ID_TAGS so a pathological rotation pattern
+    // can't blow up tag indexing on the backend; remaining ids are still in
+    // the internal-metadata JSON, just not exposed as queryable tags.
+    rumSessionIds.reserve(
+        std::min(_sessionRecordsBuffer.size(), MAX_RUM_SESSION_ID_TAGS)
+    );
+    size_t skippedSessionIds = 0;
+    for (const auto& rec : _sessionRecordsBuffer) {
+      if (rec.session_id.empty()) {
+        continue;
+      }
+      if (rumSessionIds.size() >= MAX_RUM_SESSION_ID_TAGS) {
+        ++skippedSessionIds;
+        continue;
+      }
+      rumSessionIds.push_back(rec.session_id);
+    }
+    if (skippedSessionIds > 0) {
+      Log::Warn(
+          "rum.session_id tag cap reached (",
+          MAX_RUM_SESSION_ID_TAGS,
+          "); ",
+          skippedSessionIds,
+          " session id(s) from this export not emitted as tags"
+      );
+    }
+
+    _viewRecordsBuffer.clear();
+    _sessionRecordsBuffer.clear();
   }
 
   // Write debug pprof file if enabled
@@ -297,7 +331,8 @@ bool ProfileExporter::Export(bool lastCall) {
   // Export profile to backend if enabled
   bool exportSuccess = true;
   if (_exportEnabled && _exporter.inner) {
-    exportSuccess = ExportProfile(encodedProfile, _currentExportId, rumRecordsJson);
+    exportSuccess =
+        ExportProfile(encodedProfile, _currentExportId, rumRecordsJson, rumSessionIds);
     if (!exportSuccess) {
       Log::Error("Failed to export profile to backend");
       // Continue with cleanup even if export failed
@@ -1429,7 +1464,8 @@ bool ProfileExporter::CreateExporterEndpoint(ddog_prof_Endpoint& endpoint) {
 bool ProfileExporter::ExportProfile(
     const ddog_prof_EncodedProfile* encodedProfile,
     uint32_t profileSeq,
-    const std::string& rumRecordsJson
+    const std::string& rumRecordsJson,
+    const std::vector<std::string>& rumSessionIds
 ) {
   if (!_exporter.inner || !encodedProfile) {
     _lastError = "Exporter not initialized or invalid profile";
@@ -1438,7 +1474,7 @@ bool ProfileExporter::ExportProfile(
 
   // Prepare additional tags (per-export metadata)
   ddog_Vec_Tag additionalTags = ddog_Vec_Tag_new();
-  if (!PrepareAdditionalTags(additionalTags, profileSeq)) {
+  if (!PrepareAdditionalTags(additionalTags, profileSeq, rumSessionIds)) {
     ddog_Vec_Tag_drop(additionalTags);
     return false;
   }
@@ -1549,7 +1585,11 @@ bool ProfileExporter::ExportProfile(
   return responseOk;
 }
 
-bool ProfileExporter::PrepareAdditionalTags(ddog_Vec_Tag& tags, uint32_t profileSeq) {
+bool ProfileExporter::PrepareAdditionalTags(
+    ddog_Vec_Tag& tags,
+    uint32_t profileSeq,
+    const std::vector<std::string>& rumSessionIds
+) {
   // Add profile sequence number
   if (!AddSingleTag(tags, TAG_PROFILE_SEQ, std::to_string(profileSeq))) {
     return false;
@@ -1560,18 +1600,32 @@ bool ProfileExporter::PrepareAdditionalTags(ddog_Vec_Tag& tags, uint32_t profile
     return false;
   }
 
-  // Add RUM application ID tag (set once via SetRumApplicationId)
-  if (!_rumApplicationId.empty()) {
-    if (!AddSingleTag(tags, TAG_RUM_APPLICATION_ID, _rumApplicationId)) {
+  // Emit rum.application_id (single-value, set once via SetRumApplicationId)
+  // and one rum.session_id entry per session that was active during the
+  // profile window. Session ids are also still embedded in the
+  // optional_internal_metadata_json payload under "rum_session_ids".
+  for (const auto& kv : BuildRumTags(_rumApplicationId, rumSessionIds)) {
+    if (!AddSingleTag(tags, kv.first, kv.second)) {
       return false;
     }
   }
 
-  // Note: RUM session IDs are no longer emitted as a tag. They are now
-  // embedded in the optional_internal_metadata_json payload under
-  // "rum_session_ids", alongside the per-view vitals.
-
   return true;
+}
+
+std::vector<std::pair<std::string, std::string>> ProfileExporter::BuildRumTags(
+    const std::string& applicationId, const std::vector<std::string>& sessionIds
+) {
+  std::vector<std::pair<std::string, std::string>> result;
+  if (!applicationId.empty()) {
+    result.emplace_back(TAG_RUM_APPLICATION_ID, applicationId);
+  }
+  for (const auto& sid : sessionIds) {
+    if (!sid.empty()) {
+      result.emplace_back(TAG_RUM_SESSION_ID, sid);
+    }
+  }
+  return result;
 }
 
 bool ProfileExporter::CheckExportResponse(uint16_t responseCode) {

--- a/src/dd-win-prof/ProfileExporter.h
+++ b/src/dd-win-prof/ProfileExporter.h
@@ -86,9 +86,22 @@ class ProfileExporter {
   bool ExportProfile(
       const ddog_prof_EncodedProfile* encodedProfile,
       uint32_t profileSeq,
-      const std::string& rumRecordsJson = {}
+      const std::string& rumRecordsJson = {},
+      const std::vector<std::string>& rumSessionIds = {}
   );
-  bool PrepareAdditionalTags(ddog_Vec_Tag& tags, uint32_t profileSeq);
+  bool PrepareAdditionalTags(
+      ddog_Vec_Tag& tags,
+      uint32_t profileSeq,
+      const std::vector<std::string>& rumSessionIds = {}
+  );
+
+  // Pure helper: builds the per-export RUM tag list (rum.application_id +
+  // one rum.session_id entry per non-empty id). Empty inputs are skipped.
+  // Exposed as a free helper so the tag-list construction is unit-testable;
+  // ddog_Tag is opaque and we can't read entries back out of ddog_Vec_Tag.
+  static std::vector<std::pair<std::string, std::string>> BuildRumTags(
+      const std::string& applicationId, const std::vector<std::string>& sessionIds
+  );
   bool CheckExportResponse(uint16_t responseCode);
   void CleanupExporter();
 
@@ -148,10 +161,15 @@ class ProfileExporter {
   static constexpr const char* TAG_GPU_CHIP_PREFIX = "gpu_chip_";
   static constexpr const char* TAG_GPU_RAM_PREFIX = "gpu_ram_";
 
-  // RUM tags (per-export)
+  // RUM tags (per-export). Both keys are emitted alongside one another in
+  // PrepareAdditionalTags. rum.session_id is multi-value: one tag entry per
+  // session record produced during the profile window. The same id list is
+  // also embedded in optional_internal_metadata_json under "rum_session_ids".
+  // Cardinality is capped at MAX_RUM_SESSION_ID_TAGS to guard against
+  // pathological session-rotation patterns blowing up tag count.
   static constexpr const char* TAG_RUM_APPLICATION_ID = "rum.application_id";
-  // Session IDs are no longer emitted as a tag; they are carried in the
-  // internal metadata JSON payload (optional_internal_metadata_json).
+  static constexpr const char* TAG_RUM_SESSION_ID = "rum.session_id";
+  static constexpr size_t MAX_RUM_SESSION_ID_TAGS = 10;
 
   // TODO: how to define metrics? With tags? With separate json file?
   static constexpr const char* TAG_RAM_SIZE = "ram_size";


### PR DESCRIPTION
## Summary
- Adds `rum.session_id:<uuid>` profile-level tags, one entry per completed session record produced during the profile window. Repeated entries with the same key (the standard Datadog multi-value facet shape — not comma-joined, not a JSON list) so each session id is independently queryable as `@rum.session_id:<uuid>`.
- Placed alongside `rum.application_id` in `PrepareAdditionalTags`. Reuses the existing `AddSingleTag` push helper. Both rum.* tags now live in the same code region (`ProfileExporter.cpp:1592-1620`).
- Cardinality capped at `MAX_RUM_SESSION_ID_TAGS = 10` to bound tag indexing cost on pathological session-rotation patterns. Overflow logs `Log::Warn` reporting how many ids were skipped; the full id list still travels in `optional_internal_metadata_json` (`rum_session_ids`), unaffected by the cap.
- Records are 1:1 with sessions by construction (`Profiler::CompleteCurrentSession` pushes once per session and clears `_currentSessionId`), so no dedup is needed in the collection step.

## Implementation notes
Tag-list construction is factored into a pure static helper `ProfileExporter::BuildRumTags(applicationId, sessionIds) -> vector<pair<string,string>>`. `ddog_Tag` is opaque, so we can't inspect entries back out of `ddog_Vec_Tag` after pushing — pinning the contract upstream of the push is the only way to write meaningful unit tests.

`Export()` mirrors the session ids that already feed `optional_internal_metadata_json` into a separate `rumSessionIds` vector before clearing `_sessionRecordsBuffer`, then threads that vector down through `ExportProfile` to `PrepareAdditionalTags`.

## Out of scope
The `customData["view.id"]` array (matching the chrome SDK contract for the runtime view-filter endpoint) and the `optional_info_json` channel are intentionally not in this PR.

## Test plan
Unit tests in `ProfileExporterTests.cpp`:
- [x] empty input → empty list
- [x] application id only → 1 entry (regression for the existing `rum.application_id` emit)
- [x] 1 session, 3 sessions → N+1 entries (multi-value-facet shape)
- [x] empty applicationId → only session entries
- [x] empty session ids in the list are skipped

Manual on Windows (`r1viollet`):
- [x] Scenario 5 single run: pprof shows 2 `rum.session_id:<uuid>` entries — one auto-gen'd, one `99999999-...`
- [x] Scenario 5 with 11 forced extra rotations (now removed from the runner): pprof shows exactly 10 `rum.session_id:<uuid>` entries; profiler log contains `rum.session_id tag cap reached (10); N session id(s) from this export not emitted as tags`

🤖 Generated with [Claude Code](https://claude.com/claude-code)