### PR TITLE
e2e: symbolize callstacks for the Vulkan profile

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -43,6 +43,7 @@ jobs:
         DD_PROFILING_LOG_LEVEL=debug
         DD_PROFILING_LOG_TO_CONSOLE=1
         DD_INTERNAL_PROFILING_OUTPUT_DIR=e2e-tests/pprof
+        DD_PROFILING_INTERNAL_SYMBOLIZE_CALLSTACKS=1
         "@
         New-Item -Path "e2e-tests/.env" -Value $envContent -Force
       shell: pwsh


### PR DESCRIPTION
## Summary
Sets `DD_PROFILING_INTERNAL_SYMBOLIZE_CALLSTACKS=1` in the `.env` written by the e2e job so the Vulkan run produces profiles with real function names instead of obfuscated tokens.

The env var is already wired (`EnvironmentVariables.h:46`, `Configuration.cpp:118`) — this just turns it on for CI.

## Why
- Easier manual inspection of e2e pprof artifacts when debugging.
- Prerequisite for any downstream pprof assertions (planned prof-correctness analyzer integration).

Vulkan is built Release with PDBs (`vulcan_quickstart.ps1:607-610` sets `CMAKE_MSVC_DEBUG_INFORMATION_FORMAT=ProgramDatabase` and `/DEBUG` linker flags), so the symbolizer should be able to resolve frames at runtime.

## Test plan
- [x] e2e workflow runs green
- [x] Inspect the pprof artifact (drop into the analyzer's `cmd/inspect` or `pprof -top`) to confirm frames now carry function names

🤖 Generated with [Claude Code](https://claude.com/claude-code)