### PR TITLE
ci: run unit + integration tests under MSVC AddressSanitizer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,11 +81,15 @@ jobs:
         key: deps-${{ hashFiles('src/CMakeLists.txt') }}
 
     # Sets up the MSVC Developer environment so that VCToolsInstallDir is
-    # exported and the ASan runtime DLL can be located by CMake.
+    # exported (used by CMake to locate the ASan runtime DLL) and so that
+    # Ninja + cl.exe are on PATH. Done inline rather than via a third-party
+    # action to stay within the org's allowed-actions policy.
     - name: Setup MSVC dev environment
-      uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
-      with:
-        arch: x64
+      shell: cmd
+      run: |
+        for /f "usebackq tokens=*" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do set VSINSTALL=%%i
+        call "%VSINSTALL%\VC\Auxiliary\Build\vcvars64.bat"
+        set >> %GITHUB_ENV%
 
     - name: Configure CMake (ASan)
       run: cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=Debug -DDD_WIN_PROF_ENABLE_ASAN=ON -DFETCHCONTENT_BASE_DIR=${{ github.workspace }}/.deps

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,11 +74,15 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
+    # NOTE: distinct cache key from the other jobs. FetchContent records the
+    # generator in its subbuild state, so reusing the VS-generator cache here
+    # would fail with "generator does not match". Keying on "ninja-asan"
+    # keeps this job's deps separate from the multi-config matrix.
     - name: Cache dependencies
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: .deps
-        key: deps-${{ hashFiles('src/CMakeLists.txt') }}
+        key: deps-ninja-asan-${{ hashFiles('src/CMakeLists.txt') }}
 
     # Sets up the MSVC Developer environment so that VCToolsInstallDir is
     # exported (used by CMake to locate the ASan runtime DLL) and so that

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,56 @@ jobs:
           build/src/Tests/${{ matrix.configuration }}/Tests.exe
         retention-days: 7
 
+  asan:
+    name: Tests (ASan, Debug)
+    runs-on: windows-2022
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+    - name: Cache dependencies
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: .deps
+        key: deps-${{ hashFiles('src/CMakeLists.txt') }}
+
+    # Sets up the MSVC Developer environment so that VCToolsInstallDir is
+    # exported and the ASan runtime DLL can be located by CMake.
+    - name: Setup MSVC dev environment
+      uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+      with:
+        arch: x64
+
+    - name: Configure CMake (ASan)
+      run: cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=Debug -DDD_WIN_PROF_ENABLE_ASAN=ON -DFETCHCONTENT_BASE_DIR=${{ github.workspace }}/.deps
+
+    - name: Build
+      run: cmake --build build
+
+    - name: Run unit tests under ASan
+      env:
+        # Make ASan failures fatal and produce useful diagnostics.
+        ASAN_OPTIONS: abort_on_error=1:halt_on_error=1:print_stacktrace=1:detect_leaks=0:symbolize=1
+      run: build/src/Tests/Tests.exe
+
+    - name: Setup Python
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      with:
+        python-version: '3.x'
+
+    - name: Install Python dependencies
+      run: pip install -r src/integration-tests/requirements.txt
+
+    # The Runner integration test loads the ASan-instrumented dd-win-prof.dll
+    # in-process, so the Runner itself runs under ASan too. -Config Debug
+    # matches the build above; find-runner.ps1 picks up the Ninja layout.
+    - name: Run integration tests under ASan
+      env:
+        ASAN_OPTIONS: abort_on_error=1:halt_on_error=1:print_stacktrace=1:detect_leaks=0:symbolize=1
+      run: pwsh src/integration-tests/test_rum_scenario.ps1 -Config Debug
+      shell: pwsh
+
   check-format:
     runs-on: windows-2022
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,6 +101,22 @@ jobs:
     - name: Build
       run: cmake --build build
 
+    # Sanity check: a binary compiled with /fsanitize=address has the linker
+    # auto-import clang_rt.asan_dynamic-x86_64.dll. If this grep returns
+    # nothing, ASan didn't actually instrument the TU even though configure
+    # advertised the flag -- fail the job so we don't get false confidence.
+    - name: Verify ASan instrumentation
+      shell: pwsh
+      run: |
+        $imports = & dumpbin /imports build/src/Tests/Tests.exe
+        $asan = $imports | Select-String -Pattern 'clang_rt\.asan'
+        if (-not $asan) {
+          Write-Error "Tests.exe does not import the ASan runtime; /fsanitize=address was NOT effective."
+          exit 1
+        }
+        Write-Host "ASan runtime import found:" -ForegroundColor Green
+        $asan | ForEach-Object { Write-Host "  $_" }
+
     - name: Run unit tests under ASan
       env:
         # Make ASan failures fatal and produce useful diagnostics.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,11 @@ endif()
 # Disabled by default when used as a dependency.
 option(DD_WIN_PROF_BUILD_OBFUSCATION "Build obfuscation tools (requires DIA SDK)" ${DD_WIN_PROF_IS_TOPLEVEL})
 
+# Enable MSVC AddressSanitizer for the whole project (compiler + linker).
+# Mostly intended for unit tests in CI; see src/Tests/CMakeLists.txt for the
+# runtime DLL deployment that lets Tests.exe actually launch with ASan on.
+option(DD_WIN_PROF_ENABLE_ASAN "Build with MSVC AddressSanitizer (/fsanitize=address)" OFF)
+
 add_compile_definitions(UNICODE _UNICODE)
 
 if(MSVC)
@@ -40,7 +45,78 @@ if(MSVC)
         $<$<CONFIG:Release>:/OPT:REF>
         $<$<CONFIG:Release>:/OPT:ICF>
     )
+
+    if(DD_WIN_PROF_ENABLE_ASAN)
+        message(STATUS "dd-win-prof: AddressSanitizer ENABLED (/fsanitize=address)")
+
+        # Resolve the MSVC ASan runtime DLL once, here, so every consumer
+        # (Tests.exe, Runner.exe, ...) can ask for it via the helper below.
+        # $ENV{VCToolsInstallDir} is exported by the VS Developer shell.
+        set(DD_WIN_PROF_ASAN_RUNTIME_DLL "" CACHE INTERNAL "")
+        if(DEFINED ENV{VCToolsInstallDir})
+            set(_candidate "$ENV{VCToolsInstallDir}/bin/Hostx64/x64/clang_rt.asan_dynamic-x86_64.dll")
+            if(EXISTS "${_candidate}")
+                set(DD_WIN_PROF_ASAN_RUNTIME_DLL "${_candidate}" CACHE INTERNAL "")
+            endif()
+        endif()
+        if(DD_WIN_PROF_ASAN_RUNTIME_DLL STREQUAL "")
+            message(WARNING "DD_WIN_PROF_ENABLE_ASAN: clang_rt.asan_dynamic-x86_64.dll "
+                            "could not be located. Configure from a VS Developer Command "
+                            "Prompt or set VCToolsInstallDir, otherwise instrumented "
+                            "binaries (Tests.exe, Runner.exe) will fail to start.")
+        else()
+            message(STATUS "dd-win-prof: ASan runtime DLL = ${DD_WIN_PROF_ASAN_RUNTIME_DLL}")
+        endif()
+
+        # /RTC* and /fsanitize=address are mutually exclusive. CMake injects
+        # /RTC1 by default in Debug-style configs via CMAKE_CXX_FLAGS_<CFG>;
+        # strip it from every config to keep the compiler happy.
+        foreach(_cfg "" _DEBUG _RELEASE _MINSIZEREL _RELWITHDEBINFO)
+            foreach(_lang CXX C)
+                set(_var CMAKE_${_lang}_FLAGS${_cfg})
+                if(DEFINED ${_var})
+                    string(REGEX REPLACE "/RTC[1csu]+" "" ${_var} "${${_var}}")
+                    set(${_var} "${${_var}}" CACHE STRING "" FORCE)
+                endif()
+            endforeach()
+        endforeach()
+
+        add_compile_options(/fsanitize=address)
+
+        # ASan is incompatible with incremental linking. Default Debug link
+        # flags pass /INCREMENTAL; force it off everywhere.
+        add_link_options(/INCREMENTAL:NO)
+        foreach(_cfg "" _DEBUG _RELEASE _MINSIZEREL _RELWITHDEBINFO)
+            foreach(_kind EXE SHARED MODULE)
+                set(_var CMAKE_${_kind}_LINKER_FLAGS${_cfg})
+                if(DEFINED ${_var})
+                    string(REGEX REPLACE "/INCREMENTAL(:NO)?" "" ${_var} "${${_var}}")
+                    set(${_var} "${${_var}} /INCREMENTAL:NO" CACHE STRING "" FORCE)
+                endif()
+            endforeach()
+        endforeach()
+    endif()
 endif()
+
+# Copy the MSVC AddressSanitizer runtime DLL next to a target's output. No-op
+# unless DD_WIN_PROF_ENABLE_ASAN is ON. Used by any executable target that
+# needs to launch standalone (Tests.exe, Runner.exe, ...).
+function(dd_win_prof_copy_asan_runtime TARGET_NAME)
+    if(NOT DD_WIN_PROF_ENABLE_ASAN OR NOT MSVC)
+        return()
+    endif()
+    if(DD_WIN_PROF_ASAN_RUNTIME_DLL STREQUAL "")
+        return()
+    endif()
+    get_filename_component(_dll_name "${DD_WIN_PROF_ASAN_RUNTIME_DLL}" NAME)
+    add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "${DD_WIN_PROF_ASAN_RUNTIME_DLL}"
+            "$<TARGET_FILE_DIR:${TARGET_NAME}>/${_dll_name}"
+        VERBATIM
+        COMMENT "Copying MSVC ASan runtime next to ${TARGET_NAME}"
+    )
+endfunction()
 
 add_subdirectory(src)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,77 +46,13 @@ if(MSVC)
         $<$<CONFIG:Release>:/OPT:ICF>
     )
 
-    if(DD_WIN_PROF_ENABLE_ASAN)
-        message(STATUS "dd-win-prof: AddressSanitizer ENABLED (/fsanitize=address)")
-
-        # Resolve the MSVC ASan runtime DLL once, here, so every consumer
-        # (Tests.exe, Runner.exe, ...) can ask for it via the helper below.
-        # $ENV{VCToolsInstallDir} is exported by the VS Developer shell.
-        set(DD_WIN_PROF_ASAN_RUNTIME_DLL "" CACHE INTERNAL "")
-        if(DEFINED ENV{VCToolsInstallDir})
-            set(_candidate "$ENV{VCToolsInstallDir}/bin/Hostx64/x64/clang_rt.asan_dynamic-x86_64.dll")
-            if(EXISTS "${_candidate}")
-                set(DD_WIN_PROF_ASAN_RUNTIME_DLL "${_candidate}" CACHE INTERNAL "")
-            endif()
-        endif()
-        if(DD_WIN_PROF_ASAN_RUNTIME_DLL STREQUAL "")
-            message(WARNING "DD_WIN_PROF_ENABLE_ASAN: clang_rt.asan_dynamic-x86_64.dll "
-                            "could not be located. Configure from a VS Developer Command "
-                            "Prompt or set VCToolsInstallDir, otherwise instrumented "
-                            "binaries (Tests.exe, Runner.exe) will fail to start.")
-        else()
-            message(STATUS "dd-win-prof: ASan runtime DLL = ${DD_WIN_PROF_ASAN_RUNTIME_DLL}")
-        endif()
-
-        # /RTC* and /fsanitize=address are mutually exclusive. CMake injects
-        # /RTC1 by default in Debug-style configs via CMAKE_CXX_FLAGS_<CFG>;
-        # strip it from every config to keep the compiler happy.
-        foreach(_cfg "" _DEBUG _RELEASE _MINSIZEREL _RELWITHDEBINFO)
-            foreach(_lang CXX C)
-                set(_var CMAKE_${_lang}_FLAGS${_cfg})
-                if(DEFINED ${_var})
-                    string(REGEX REPLACE "/RTC[1csu]+" "" ${_var} "${${_var}}")
-                    set(${_var} "${${_var}}" CACHE STRING "" FORCE)
-                endif()
-            endforeach()
-        endforeach()
-
-        add_compile_options(/fsanitize=address)
-
-        # ASan is incompatible with incremental linking. Default Debug link
-        # flags pass /INCREMENTAL; force it off everywhere.
-        add_link_options(/INCREMENTAL:NO)
-        foreach(_cfg "" _DEBUG _RELEASE _MINSIZEREL _RELWITHDEBINFO)
-            foreach(_kind EXE SHARED MODULE)
-                set(_var CMAKE_${_kind}_LINKER_FLAGS${_cfg})
-                if(DEFINED ${_var})
-                    string(REGEX REPLACE "/INCREMENTAL(:NO)?" "" ${_var} "${${_var}}")
-                    set(${_var} "${${_var}} /INCREMENTAL:NO" CACHE STRING "" FORCE)
-                endif()
-            endforeach()
-        endforeach()
-    endif()
 endif()
 
-# Copy the MSVC AddressSanitizer runtime DLL next to a target's output. No-op
-# unless DD_WIN_PROF_ENABLE_ASAN is ON. Used by any executable target that
-# needs to launch standalone (Tests.exe, Runner.exe, ...).
-function(dd_win_prof_copy_asan_runtime TARGET_NAME)
-    if(NOT DD_WIN_PROF_ENABLE_ASAN OR NOT MSVC)
-        return()
-    endif()
-    if(DD_WIN_PROF_ASAN_RUNTIME_DLL STREQUAL "")
-        return()
-    endif()
-    get_filename_component(_dll_name "${DD_WIN_PROF_ASAN_RUNTIME_DLL}" NAME)
-    add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            "${DD_WIN_PROF_ASAN_RUNTIME_DLL}"
-            "$<TARGET_FILE_DIR:${TARGET_NAME}>/${_dll_name}"
-        VERBATIM
-        COMMENT "Copying MSVC ASan runtime next to ${TARGET_NAME}"
-    )
-endfunction()
+# AddressSanitizer plumbing: option handling, compile/link flag adjustments,
+# runtime DLL discovery, and the dd_win_prof_copy_asan_runtime() helper used
+# by Tests/Runner to ship the ASan DLL next to instrumented binaries.
+include(cmake/asan.cmake)
+dd_win_prof_setup_asan()
 
 add_subdirectory(src)
 

--- a/README.md
+++ b/README.md
@@ -182,6 +182,29 @@ Run the helper script to generate and open the solution:
 
 This generates a Visual Studio solution in `build\` and opens it automatically. You can then build and debug directly from the IDE. See `.\scripts\generate-vs.ps1 -?` for options (custom build directory, VS version, etc.).
 
+#### Building with AddressSanitizer
+
+To get an ASan-instrumented solution, pass `-Asan` and use a separate build
+directory so it does not clobber your regular `build\`:
+
+```powershell
+.\scripts\generate-vs.ps1 -BuildDir build-asan -Asan
+```
+
+This configures CMake with `-DDD_WIN_PROF_ENABLE_ASAN=ON` and opens the
+resulting solution. Every configuration in that solution (Debug, Release, ...)
+will be ASan-instrumented; pick Debug from the VS dropdown for typical use.
+
+Requirements:
+- The **C++ AddressSanitizer** component must be installed via the Visual
+  Studio Installer (`Modify` → *Individual components* → search "AddressSanitizer").
+- No Developer Command Prompt needed: the build locates the ASan runtime DLL
+  (`clang_rt.asan_dynamic-x86_64.dll`) automatically via `vswhere` and copies
+  it next to `Tests.exe` and `Runner.exe`.
+
+To switch back to a non-ASan build, just open the original `build\` solution
+(or generate one without `-Asan`).
+
 ### Project structure and build outputs
 
 ```

--- a/cmake/asan.cmake
+++ b/cmake/asan.cmake
@@ -1,0 +1,138 @@
+# MSVC AddressSanitizer plumbing for dd-win-prof.
+#
+# Provides two public entry points:
+#   dd_win_prof_setup_asan()            - call once from the top-level
+#                                         CMakeLists after project(); applies
+#                                         /fsanitize=address project-wide and
+#                                         resolves the runtime DLL location.
+#   dd_win_prof_copy_asan_runtime(<tgt>) - post-build copy of the ASan runtime
+#                                         DLL next to <tgt>'s output. No-op
+#                                         when ASan is OFF.
+#
+# Both no-op unless DD_WIN_PROF_ENABLE_ASAN is ON and the toolchain is MSVC.
+
+# Strip a flag matched by <regex> from every standard CMAKE_<lang>_FLAGS_<cfg>
+# cache variable. Used to remove options that are incompatible with ASan
+# (/RTC* for compile flags, /INCREMENTAL for link flags).
+function(_dd_strip_msvc_flag REGEX VAR_PREFIX_LIST)
+    foreach(_prefix IN LISTS VAR_PREFIX_LIST)
+        foreach(_cfg "" _DEBUG _RELEASE _MINSIZEREL _RELWITHDEBINFO)
+            set(_var ${_prefix}${_cfg})
+            if(DEFINED ${_var})
+                string(REGEX REPLACE "${REGEX}" "" _new "${${_var}}")
+                set(${_var} "${_new}" CACHE STRING "" FORCE)
+            endif()
+        endforeach()
+    endforeach()
+endfunction()
+
+# Append <flag> to every standard CMAKE_<linker_kind>_LINKER_FLAGS_<cfg>.
+function(_dd_append_linker_flag FLAG)
+    foreach(_kind EXE SHARED MODULE)
+        foreach(_cfg "" _DEBUG _RELEASE _MINSIZEREL _RELWITHDEBINFO)
+            set(_var CMAKE_${_kind}_LINKER_FLAGS${_cfg})
+            if(DEFINED ${_var})
+                set(${_var} "${${_var}} ${FLAG}" CACHE STRING "" FORCE)
+            endif()
+        endforeach()
+    endforeach()
+endfunction()
+
+# Resolve clang_rt.asan_dynamic-x86_64.dll. Writes the absolute path into the
+# parent-scope variable named by OUT_VAR, or "" if not found.
+#
+# Lookup order:
+#   1. $ENV{VCToolsInstallDir}     - set inside a VS Developer Command Prompt.
+#   2. vswhere.exe                 - lives at a documented stable path on
+#                                    every machine with VS 2017+ installed,
+#                                    so this also works from a plain shell.
+function(_dd_find_asan_runtime_dll OUT_VAR)
+    set(_rel "bin/Hostx64/x64/clang_rt.asan_dynamic-x86_64.dll")
+    set(_found "")
+
+    if(DEFINED ENV{VCToolsInstallDir})
+        set(_candidate "$ENV{VCToolsInstallDir}/${_rel}")
+        if(EXISTS "${_candidate}")
+            set(_found "${_candidate}")
+        endif()
+    endif()
+
+    if(_found STREQUAL "")
+        set(_vswhere "$ENV{ProgramFiles\(x86\)}/Microsoft Visual Studio/Installer/vswhere.exe")
+        if(NOT EXISTS "${_vswhere}")
+            set(_vswhere "C:/Program Files (x86)/Microsoft Visual Studio/Installer/vswhere.exe")
+        endif()
+        if(EXISTS "${_vswhere}")
+            execute_process(
+                COMMAND "${_vswhere}" -latest -products *
+                        -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64
+                        -property installationPath
+                OUTPUT_VARIABLE _vs_install
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+            )
+            set(_stamp "${_vs_install}/VC/Auxiliary/Build/Microsoft.VCToolsVersion.default.txt")
+            if(_vs_install AND EXISTS "${_stamp}")
+                file(READ "${_stamp}" _vc_ver)
+                string(STRIP "${_vc_ver}" _vc_ver)
+                set(_candidate "${_vs_install}/VC/Tools/MSVC/${_vc_ver}/${_rel}")
+                if(EXISTS "${_candidate}")
+                    set(_found "${_candidate}")
+                endif()
+            endif()
+        endif()
+    endif()
+
+    set(${OUT_VAR} "${_found}" PARENT_SCOPE)
+endfunction()
+
+# Public: enable ASan project-wide.
+function(dd_win_prof_setup_asan)
+    if(NOT DD_WIN_PROF_ENABLE_ASAN OR NOT MSVC)
+        return()
+    endif()
+
+    message(STATUS "dd-win-prof: AddressSanitizer ENABLED (/fsanitize=address)")
+
+    _dd_find_asan_runtime_dll(_dll)
+    set(DD_WIN_PROF_ASAN_RUNTIME_DLL "${_dll}" CACHE INTERNAL "")
+    if(_dll STREQUAL "")
+        message(WARNING "DD_WIN_PROF_ENABLE_ASAN: clang_rt.asan_dynamic-x86_64.dll "
+                        "could not be located via VCToolsInstallDir or vswhere. "
+                        "Ensure the 'C++ AddressSanitizer' component is installed via "
+                        "the Visual Studio Installer, otherwise instrumented binaries "
+                        "(Tests.exe, Runner.exe) will fail to start.")
+    else()
+        message(STATUS "dd-win-prof: ASan runtime DLL = ${_dll}")
+    endif()
+
+    # /RTC* and /fsanitize=address are mutually exclusive. CMake injects /RTC1
+    # by default in Debug-style configs; strip it from every config.
+    _dd_strip_msvc_flag("/RTC[1csu]+" "CMAKE_CXX_FLAGS;CMAKE_C_FLAGS")
+
+    # /INCREMENTAL is also incompatible. Strip any existing form and force NO.
+    _dd_strip_msvc_flag("/INCREMENTAL(:NO)?"
+        "CMAKE_EXE_LINKER_FLAGS;CMAKE_SHARED_LINKER_FLAGS;CMAKE_MODULE_LINKER_FLAGS")
+    _dd_append_linker_flag("/INCREMENTAL:NO")
+
+    add_compile_options(/fsanitize=address)
+    add_link_options(/INCREMENTAL:NO)
+endfunction()
+
+# Public: copy the ASan runtime DLL next to <target_name>'s output. No-op when
+# ASan is OFF or the DLL could not be located.
+function(dd_win_prof_copy_asan_runtime TARGET_NAME)
+    if(NOT DD_WIN_PROF_ENABLE_ASAN OR NOT MSVC)
+        return()
+    endif()
+    if(DD_WIN_PROF_ASAN_RUNTIME_DLL STREQUAL "")
+        return()
+    endif()
+    get_filename_component(_dll_name "${DD_WIN_PROF_ASAN_RUNTIME_DLL}" NAME)
+    add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "${DD_WIN_PROF_ASAN_RUNTIME_DLL}"
+            "$<TARGET_FILE_DIR:${TARGET_NAME}>/${_dll_name}"
+        VERBATIM
+        COMMENT "Copying MSVC ASan runtime next to ${TARGET_NAME}"
+    )
+endfunction()

--- a/scripts/generate-vs.ps1
+++ b/scripts/generate-vs.ps1
@@ -15,14 +15,21 @@
 .PARAMETER NoOpen
     Skip opening the solution in Visual Studio after generation.
 
+.PARAMETER Asan
+    Configure the solution with AddressSanitizer enabled
+    (-DDD_WIN_PROF_ENABLE_ASAN=ON). Affects all configs in the resulting
+    solution; use a separate -BuildDir to keep ASan and non-ASan builds.
+
 .EXAMPLE
     .\scripts\generate-vs.ps1
     .\scripts\generate-vs.ps1 -BuildDir out\vs -NoOpen
+    .\scripts\generate-vs.ps1 -BuildDir build-asan -Asan
 #>
 param(
     [string]$BuildDir = "build",
     [string]$Generator = "Visual Studio 17 2022",
-    [switch]$NoOpen
+    [switch]$NoOpen,
+    [switch]$Asan
 )
 
 $ErrorActionPreference = "Stop"
@@ -30,8 +37,14 @@ $ErrorActionPreference = "Stop"
 $ProjectRoot = Split-Path -Parent $PSScriptRoot
 Push-Location $ProjectRoot
 try {
+    $cmakeArgs = @("-G", $Generator, "-B", $BuildDir)
+    if ($Asan) {
+        Write-Host "AddressSanitizer ENABLED (DD_WIN_PROF_ENABLE_ASAN=ON)" -ForegroundColor Yellow
+        $cmakeArgs += "-DDD_WIN_PROF_ENABLE_ASAN=ON"
+    }
+
     Write-Host "Generating Visual Studio solution in '$BuildDir'..." -ForegroundColor Cyan
-    cmake -G "$Generator" -B "$BuildDir"
+    cmake @cmakeArgs
     if ($LASTEXITCODE -ne 0) {
         Write-Error "CMake configure failed."
         exit 1

--- a/src/Runner/CMakeLists.txt
+++ b/src/Runner/CMakeLists.txt
@@ -43,3 +43,8 @@ add_custom_command(
 add_custom_target(Runner_runtime_deps DEPENDS "${_runner_runtime_deps_stamp}")
 add_dependencies(Runner_runtime_deps dd-win-prof)
 add_dependencies(Runner Runner_runtime_deps)
+
+# When ASan is on, Runner.exe (and the dd-win-prof.dll it loads) are both
+# instrumented and need the MSVC ASan runtime DLL alongside the executable.
+# No-op when DD_WIN_PROF_ENABLE_ASAN is OFF.
+dd_win_prof_copy_asan_runtime(Runner)

--- a/src/Runner/find-runner.ps1
+++ b/src/Runner/find-runner.ps1
@@ -24,8 +24,11 @@ function Find-Runner {
     foreach ($cfg in $configs) {
         $candidates += (Join-Path $ScriptDir "x64\$cfg\Runner.exe")          # MSBuild output: src/Runner/x64/<cfg>/
         $candidates += (Join-Path $ScriptDir "..\x64\$cfg\Runner.exe")       # legacy: src/x64/<cfg>/
-        $candidates += (Join-Path $ScriptDir "..\..\build\src\Runner\$cfg\Runner.exe")  # CMake output
+        $candidates += (Join-Path $ScriptDir "..\..\build\src\Runner\$cfg\Runner.exe")  # CMake (multi-config: VS)
     }
+    # Single-config generators (Ninja, Make) drop the binary directly under
+    # build/src/Runner/Runner.exe with no per-config subdirectory.
+    $candidates += (Join-Path $ScriptDir "..\..\build\src\Runner\Runner.exe")
 
     foreach ($path in $candidates) {
         if (Test-Path $path) {

--- a/src/Tests/CMakeLists.txt
+++ b/src/Tests/CMakeLists.txt
@@ -82,5 +82,10 @@ add_custom_command(TARGET Tests POST_BUILD
     COMMENT "Copying libdatadog DLLs to Tests output directory"
 )
 
+# When building with /fsanitize=address, Tests.exe depends on the MSVC ASan
+# runtime DLL, which lives inside the Visual Studio install and is not on PATH
+# for arbitrary shells. Helper drops it next to the exe (no-op otherwise).
+dd_win_prof_copy_asan_runtime(Tests)
+
 include(CTest)
 add_test(NAME Tests COMMAND Tests)

--- a/src/Tests/UuidTests.cpp
+++ b/src/Tests/UuidTests.cpp
@@ -18,17 +18,6 @@ class UuidTest : public ::testing::Test {
   }
 };
 
-// TEMP: deliberate ASan canary -- writes one byte past a heap allocation.
-// Used to validate that the CI ASan job actually catches real bugs.
-// MUST be reverted before merging.
-TEST_F(UuidTest, AsanCanaryHeapBufferOverflow) {
-  volatile char* buf = new char[8];
-  for (int i = 0; i <= 8; ++i) {
-    buf[i] = static_cast<char>(i);  // off-by-one at i == 8
-  }
-  delete[] buf;
-}
-
 TEST_F(UuidTest, CanCreateUuid) {
   // Arrange & Act
   ddprof::Uuid uuid;

--- a/src/Tests/UuidTests.cpp
+++ b/src/Tests/UuidTests.cpp
@@ -18,6 +18,17 @@ class UuidTest : public ::testing::Test {
   }
 };
 
+// TEMP: deliberate ASan canary -- writes one byte past a heap allocation.
+// Used to validate that the CI ASan job actually catches real bugs.
+// MUST be reverted before merging.
+TEST_F(UuidTest, AsanCanaryHeapBufferOverflow) {
+  volatile char* buf = new char[8];
+  for (int i = 0; i <= 8; ++i) {
+    buf[i] = static_cast<char>(i);  // off-by-one at i == 8
+  }
+  delete[] buf;
+}
+
 TEST_F(UuidTest, CanCreateUuid) {
   // Arrange & Act
   ddprof::Uuid uuid;


### PR DESCRIPTION
## What

Adds a CI job that builds dd-win-prof (Debug, Ninja) with MSVC AddressSanitizer (`/fsanitize=address`) and runs both the unit tests (`Tests.exe`) and the RUM integration scenario (`test_rum_scenario.ps1`) under ASan.

## Why

We had no sanitizer coverage on Windows. The Runner integration test loads the profiler DLL in-process, so running it under ASan exercises the real consumption path end-to-end.

## How

- New CMake option `DD_WIN_PROF_ENABLE_ASAN` enables `/fsanitize=address` project-wide, strips incompatible `/RTC*` and `/INCREMENTAL` flags, and resolves `clang_rt.asan_dynamic-x86_64.dll` from `%VCToolsInstallDir%`.
- Helper `dd_win_prof_copy_asan_runtime(<target>)` drops the runtime DLL next to instrumented executables (Tests.exe, Runner.exe) so they can launch standalone.
- `find-runner.ps1` now also recognises the Ninja single-config layout (`build/src/Runner/Runner.exe`).
- New `asan` job in `test.yml`:
  - sets up the MSVC dev shell (`ilammy/msvc-dev-cmd`) so `VCToolsInstallDir` is exported
  - configures with `-G Ninja -DCMAKE_BUILD_TYPE=Debug -DDD_WIN_PROF_ENABLE_ASAN=ON`
  - runs `Tests.exe` with `ASAN_OPTIONS=abort_on_error=1:halt_on_error=1:print_stacktrace=1:detect_leaks=0:symbolize=1`
  - runs `test_rum_scenario.ps1 -Config Debug` with the same `ASAN_OPTIONS`

## Notes

- The existing Debug/Release matrix and `check-format` / `e2e-tests` jobs are unchanged.
- `detect_leaks=0` because MSVC ASan doesn't ship LSan.