### PR TITLE
Runner: keep scenario helpers observable in Release profiles

### DIFF
--- a/src/Runner/Helpers.cpp
+++ b/src/Runner/Helpers.cpp
@@ -8,7 +8,7 @@
 
 #include "Windows.h"
 
-void Spin(int durationMS) {
+__declspec(noinline) void Spin(int durationMS) {
   auto start = ::GetTickCount64();
   auto current = ::GetTickCount64();
   do {

--- a/src/Runner/Helpers.h
+++ b/src/Runner/Helpers.h
@@ -4,4 +4,8 @@
 
 #pragma once
 
-void Spin(int durationMS);
+// Test scenario helpers — declared noinline so they stay observable as
+// distinct frames in Release-build profiles. Without this, MSVC inlines
+// them into the caller and the prof-correctness analyzer can't assert on
+// per-function CPU shares.
+__declspec(noinline) void Spin(int durationMS);

--- a/src/Runner/Runner.cpp
+++ b/src/Runner/Runner.cpp
@@ -48,14 +48,17 @@ struct RunnerOptions {
 void ShowHelp(const char* programName);
 bool ParseCommandLine(int argc, char* argv[], RunnerOptions& opts);
 
-void SimpleCall2() { Spin(100); }
+// Noinline so each function stays observable as a distinct frame in
+// Release-build profiles. The prof-correctness analyzer asserts on
+// per-function CPU shares; inlining collapses them all into the caller.
+__declspec(noinline) void SimpleCall2() { Spin(100); }
 
-void SimpleCall1() {
+__declspec(noinline) void SimpleCall1() {
   Spin(200);
   SimpleCall2();
 }
 
-void SimpleCalls() {
+__declspec(noinline) void SimpleCalls() {
   for (int count = 0; count < 3; count++) {
     Spin(300);
     SimpleCall1();


### PR DESCRIPTION
## Summary
Annotate `SimpleCalls`, `SimpleCall1`, `SimpleCall2` and `Spin` with `__declspec(noinline)` so each one stays a distinct frame in Release-build profiles.

## Why
In Release MSVC inlines these tiny helpers into `main`. The PDB still carries the symbols but every captured sample resolves directly to `main` — there is no `SimpleCalls;Spin` frame, no `SimpleCall1;Spin` frame, etc. The prof-correctness analyzer assertions in DataDog/dd-win-prof#46 then see 0% across the board:

```
Assertion failed: stack ';SimpleCalls;Spin(;|$)' (labels=[]) should have been 50% +/- 15% of the profile but was 0% with 50% error
Assertion failed: stack ';SimpleCall1;Spin(;|$)' (labels=[]) should have been 33% +/- 15% of the profile but was 0% with 33% error
Assertion failed: stack ';SimpleCall2;Spin(;|$)' (labels=[]) should have been 17% +/- 10% of the profile but was 0% with 17% error
```

Confirmed by grepping the CI capture artifact: `main` appears 8×, `GetTickCount64` appears 4×, but `SimpleCalls` / `SimpleCall1` / `SimpleCall2` / `Spin` appear 0×.

## Tradeoff
This means inlined functions are not detected by the profiler today. Proper inline-frame symbolization (via `SymGetLineFromInlineContext` / `SymFromInlineContext` on the PDB) is a separate, larger change; opening it as a follow-up makes sense once the basic scenario plumbing is green.

## Scope
- `src/Runner/Helpers.h` — annotate `Spin` declaration.
- `src/Runner/Helpers.cpp` — annotate `Spin` definition.
- `src/Runner/Runner.cpp` — annotate `SimpleCalls`, `SimpleCall1`, `SimpleCall2`.

No behavior change for existing tests/scenarios — `__declspec(noinline)` just prevents inlining of those four functions.

## Downstream
Unblocks #46. After this merges, that PR's CI run should produce the expected 50 / 33 / 17 split and the analyzer assertions will pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)