### PR TITLE
[PROF-14955] perf(sampler): collapse double GetThreadContext on the sampling hot path

### DIFF
--- a/src/dd-win-prof/StackFrameCollector.cpp
+++ b/src/dd-win-prof/StackFrameCollector.cpp
@@ -21,7 +21,7 @@ bool StackFrameCollector::CaptureStack(
 
 bool StackFrameCollector::CaptureStack(
     HANDLE hThread,
-    const CONTEXT& seedContext,
+    CONTEXT& context,
     uint64_t* pFrames,
     uint16_t& framesCount,
     bool& isTruncated
@@ -29,10 +29,10 @@ bool StackFrameCollector::CaptureStack(
   isTruncated = false;
   uint16_t maxFramesCount = framesCount;
 
-  // RtlVirtualUnwind mutates the context as it walks frames, so work on a copy
-  // of the seed obtained by TrySuspendThread. No GetThreadContext call here:
-  // the suspend + fetch already happened in TrySuspendThread.
-  CONTEXT context = seedContext;
+  // No GetThreadContext call here: the suspend + fetch already happened in
+  // TrySuspendThread. RtlVirtualUnwind mutates `context` as it walks frames;
+  // the caller (StackSamplerLoop) does not read it back, so we avoid the
+  // ~1.2 KB-per-sample copy that a const-ref + local snapshot would cost.
 
   // Get thread stack limits:
   DWORD64 stackLimit = 0;

--- a/src/dd-win-prof/StackFrameCollector.cpp
+++ b/src/dd-win-prof/StackFrameCollector.cpp
@@ -20,18 +20,19 @@ bool StackFrameCollector::CaptureStack(
 }
 
 bool StackFrameCollector::CaptureStack(
-    HANDLE hThread, uint64_t* pFrames, uint16_t& framesCount, bool& isTruncated
+    HANDLE hThread,
+    const CONTEXT& seedContext,
+    uint64_t* pFrames,
+    uint16_t& framesCount,
+    bool& isTruncated
 ) {
   isTruncated = false;
   uint16_t maxFramesCount = framesCount;
 
-  CONTEXT context;
-  context.ContextFlags = CONTEXT_FULL;
-  BOOL hasInfo = ::GetThreadContext(hThread, &context);
-
-  if (!hasInfo) {
-    return false;
-  }
+  // RtlVirtualUnwind mutates the context as it walks frames, so work on a copy
+  // of the seed obtained by TrySuspendThread. No GetThreadContext call here:
+  // the suspend + fetch already happened in TrySuspendThread.
+  CONTEXT context = seedContext;
 
   // Get thread stack limits:
   DWORD64 stackLimit = 0;
@@ -144,7 +145,9 @@ bool StackFrameCollector::CaptureStack(
   return true;
 }
 
-bool StackFrameCollector::TrySuspendThread(std::shared_ptr<ThreadInfo> pThreadInfo) {
+bool StackFrameCollector::TrySuspendThread(
+    std::shared_ptr<ThreadInfo> pThreadInfo, CONTEXT& outContext
+) {
   HANDLE hThread = pThreadInfo->GetOsThreadHandle();
   DWORD suspendCount = ::SuspendThread(hThread);
   if (suspendCount == static_cast<DWORD>(-1)) {
@@ -160,9 +163,15 @@ bool StackFrameCollector::TrySuspendThread(std::shared_ptr<ThreadInfo> pThreadIn
   // suspension management (and we have biger problems if we do not), this should be
   // benign.
 
-  // SuspendThread is asynchronous and requires GetThreadContext to be called.
+  // SuspendThread is asynchronous; the kernel only guarantees the thread is fully
+  // stopped once we have observed its register state. We need the CONTEXT anyway
+  // as the unwind seed, so fetch it here with CONTEXT_FULL. This single
+  // GetThreadContext call serves as both the suspend fence and the seed for
+  // CaptureStack, replacing the previous double-fetch (one CONTEXT_INTEGER fence
+  // + one CONTEXT_FULL seed).
   // https://devblogs.microsoft.com/oldnewthing/20150205-00/?p=44743
-  if (EnsureThreadIsSuspended(hThread)) {
+  outContext.ContextFlags = CONTEXT_FULL;
+  if (::GetThreadContext(hThread, &outContext)) {
     return true;
   }
 

--- a/src/dd-win-prof/StackFrameCollector.cpp
+++ b/src/dd-win-prof/StackFrameCollector.cpp
@@ -21,7 +21,7 @@ bool StackFrameCollector::CaptureStack(
 
 bool StackFrameCollector::CaptureStack(
     HANDLE hThread,
-    CONTEXT& context,
+    CONTEXT& seedContext,
     uint64_t* pFrames,
     uint16_t& framesCount,
     bool& isTruncated
@@ -30,9 +30,9 @@ bool StackFrameCollector::CaptureStack(
   uint16_t maxFramesCount = framesCount;
 
   // No GetThreadContext call here: the suspend + fetch already happened in
-  // TrySuspendThread. RtlVirtualUnwind mutates `context` as it walks frames;
-  // the caller (StackSamplerLoop) does not read it back, so we avoid the
-  // ~1.2 KB-per-sample copy that a const-ref + local snapshot would cost.
+  // TrySuspendThread. RtlVirtualUnwind mutates `seedContext` as it walks
+  // frames; the caller (StackSamplerLoop) does not read it back, so we avoid
+  // the ~1.2 KB-per-sample copy that a const-ref + local snapshot would cost.
 
   // Get thread stack limits:
   DWORD64 stackLimit = 0;
@@ -55,13 +55,13 @@ bool StackFrameCollector::CaptureStack(
       isTruncated = true;
       break;
     }
-    pFrames[framesCount++] = context.Rip;
+    pFrames[framesCount++] = seedContext.Rip;
 
     __try {
       // Sometimes, we could hit an access violation, so catch it and just return.
       // We want to prevent this from killing the application
       pFunctionTableEntry =
-          ::RtlLookupFunctionEntry(context.Rip, &imageBaseAddress, &historyTable);
+          ::RtlLookupFunctionEntry(seedContext.Rip, &imageBaseAddress, &historyTable);
     } __except (EXCEPTION_EXECUTE_HANDLER) {
       return false;
     }
@@ -98,12 +98,12 @@ bool StackFrameCollector::CaptureStack(
         // FIX: For a customer using the SentinelOne solution, it was not possible to
         // walk the stack
         //      of a thread so RSP was not valid
-        context.Rip = *reinterpret_cast<uint64_t*>(context.Rsp);
+        seedContext.Rip = *reinterpret_cast<uint64_t*>(seedContext.Rsp);
       } __except (EXCEPTION_EXECUTE_HANDLER) {
         return false;
       }
 
-      context.Rsp += 8;
+      seedContext.Rsp += 8;
     } else {
       // So, pFunctionTableEntry is not NULL. Unwind one frame.
       __try {
@@ -113,9 +113,9 @@ bool StackFrameCollector::CaptureStack(
         ::RtlVirtualUnwind(
             UNW_FLAG_NHANDLER,
             imageBaseAddress,
-            context.Rip,
+            seedContext.Rip,
             pFunctionTableEntry,
-            &context,
+            &seedContext,
             &pHandlerData,
             &establisherFrame,
             pNonVolatileContextPtrsIsNull
@@ -136,17 +136,17 @@ bool StackFrameCollector::CaptureStack(
       }
     }
 
-    if (!ValidatePointerInStack(context.Rsp, stackLimit, stackBase)) {
+    if (!ValidatePointerInStack(seedContext.Rsp, stackLimit, stackBase)) {
       return false;
     }
 
-  } while (context.Rip != 0);
+  } while (seedContext.Rip != 0);
 
   return true;
 }
 
 bool StackFrameCollector::TrySuspendThread(
-    std::shared_ptr<ThreadInfo> pThreadInfo, CONTEXT& outContext
+    std::shared_ptr<ThreadInfo> pThreadInfo, CONTEXT& seedContext
 ) {
   HANDLE hThread = pThreadInfo->GetOsThreadHandle();
   DWORD suspendCount = ::SuspendThread(hThread);
@@ -170,8 +170,8 @@ bool StackFrameCollector::TrySuspendThread(
   // CaptureStack, replacing the previous double-fetch (one CONTEXT_INTEGER fence
   // + one CONTEXT_FULL seed).
   // https://devblogs.microsoft.com/oldnewthing/20150205-00/?p=44743
-  outContext.ContextFlags = CONTEXT_FULL;
-  if (::GetThreadContext(hThread, &outContext)) {
+  seedContext.ContextFlags = CONTEXT_FULL;
+  if (::GetThreadContext(hThread, &seedContext)) {
     return true;
   }
 

--- a/src/dd-win-prof/StackFrameCollector.h
+++ b/src/dd-win-prof/StackFrameCollector.h
@@ -36,9 +36,7 @@ class StackFrameCollector {
   // https://devblogs.microsoft.com/oldnewthing/20150205-00/?p=44743).
   // On success, outContext is populated with CONTEXT_FULL and the caller MUST
   // eventually call ::ResumeThread on the thread.
-  bool TrySuspendThread(
-      std::shared_ptr<ThreadInfo> pThreadInfo, CONTEXT& outContext
-  );
+  bool TrySuspendThread(std::shared_ptr<ThreadInfo> pThreadInfo, CONTEXT& outContext);
 
  private:
   bool TryGetThreadStackBoundaries(

--- a/src/dd-win-prof/StackFrameCollector.h
+++ b/src/dd-win-prof/StackFrameCollector.h
@@ -19,10 +19,26 @@ class StackFrameCollector {
       uint32_t threadID, uint64_t* pFrames, uint16_t& framesCount, bool& isTruncated
   );
 
+  // Unwind the (already suspended) thread starting from the provided seed
+  // CONTEXT. The seed is expected to come from TrySuspendThread; CaptureStack
+  // does not query the thread context itself.
   bool CaptureStack(
-      HANDLE hThread, uint64_t* pFrames, uint16_t& framesCount, bool& isTruncated
+      HANDLE hThread,
+      const CONTEXT& seedContext,
+      uint64_t* pFrames,
+      uint16_t& framesCount,
+      bool& isTruncated
   );
-  bool TrySuspendThread(std::shared_ptr<ThreadInfo> pThreadInfo);
+
+  // Suspend the target thread and fetch its CONTEXT in a single GetThreadContext
+  // call. The successful GetThreadContext also acts as the synchronization fence
+  // required after the asynchronous SuspendThread (see
+  // https://devblogs.microsoft.com/oldnewthing/20150205-00/?p=44743).
+  // On success, outContext is populated with CONTEXT_FULL and the caller MUST
+  // eventually call ::ResumeThread on the thread.
+  bool TrySuspendThread(
+      std::shared_ptr<ThreadInfo> pThreadInfo, CONTEXT& outContext
+  );
 
  private:
   bool TryGetThreadStackBoundaries(
@@ -31,13 +47,6 @@ class StackFrameCollector {
   bool ValidatePointerInStack(
       DWORD64 pointerValue, DWORD64 stackLimit, DWORD64 stackBase
   );
-
-  inline bool EnsureThreadIsSuspended(HANDLE hThread) {
-    CONTEXT ctx;
-    ctx.ContextFlags = CONTEXT_INTEGER;
-
-    return ::GetThreadContext(hThread, &ctx);
-  }
 
  private:
   // Function pointer for NtQueryInformationThread

--- a/src/dd-win-prof/StackFrameCollector.h
+++ b/src/dd-win-prof/StackFrameCollector.h
@@ -22,9 +22,14 @@ class StackFrameCollector {
   // Unwind the (already suspended) thread starting from the provided seed
   // CONTEXT. The seed is expected to come from TrySuspendThread; CaptureStack
   // does not query the thread context itself.
+  // NOTE: the context is taken by non-const reference and is MUTATED by
+  // RtlVirtualUnwind frame-by-frame during the walk. CONTEXT is ~1.2 KB on
+  // x64, so we avoid copying it on every sample by letting the caller's
+  // stack-allocated CONTEXT be the working buffer. Callers must not rely on
+  // its contents after CaptureStack returns.
   bool CaptureStack(
       HANDLE hThread,
-      const CONTEXT& seedContext,
+      CONTEXT& context,
       uint64_t* pFrames,
       uint16_t& framesCount,
       bool& isTruncated

--- a/src/dd-win-prof/StackFrameCollector.h
+++ b/src/dd-win-prof/StackFrameCollector.h
@@ -29,7 +29,7 @@ class StackFrameCollector {
   // its contents after CaptureStack returns.
   bool CaptureStack(
       HANDLE hThread,
-      CONTEXT& context,
+      CONTEXT& seedContext,
       uint64_t* pFrames,
       uint16_t& framesCount,
       bool& isTruncated
@@ -39,9 +39,9 @@ class StackFrameCollector {
   // call. The successful GetThreadContext also acts as the synchronization fence
   // required after the asynchronous SuspendThread (see
   // https://devblogs.microsoft.com/oldnewthing/20150205-00/?p=44743).
-  // On success, outContext is populated with CONTEXT_FULL and the caller MUST
+  // On success, seedContext is populated with CONTEXT_FULL and the caller MUST
   // eventually call ::ResumeThread on the thread.
-  bool TrySuspendThread(std::shared_ptr<ThreadInfo> pThreadInfo, CONTEXT& outContext);
+  bool TrySuspendThread(std::shared_ptr<ThreadInfo> pThreadInfo, CONTEXT& seedContext);
 
  private:
   bool TryGetThreadStackBoundaries(

--- a/src/dd-win-prof/StackSamplerLoop.cpp
+++ b/src/dd-win-prof/StackSamplerLoop.cpp
@@ -234,8 +234,11 @@ void StackSamplerLoop::CollectOneThreadSample(
     PROFILING_TYPE profilingType,
     ULONG waitingReason
 ) {
-  // the thread needs to be suspended before capturing the stack
-  if (!_stackFrameCollector.TrySuspendThread(pThreadInfo)) {
+  // Suspend the thread AND grab its CONTEXT in one shot. The CONTEXT acts both
+  // as the suspend-fence (per Raymond Chen) and as the unwind seed below, so we
+  // pay for a single GetThreadContext per sample instead of two.
+  CONTEXT seedContext;
+  if (!_stackFrameCollector.TrySuspendThread(pThreadInfo, seedContext)) {
     return;
   }
 
@@ -243,7 +246,11 @@ void StackSamplerLoop::CollectOneThreadSample(
   uint64_t frames[MaxFrameCount];
   uint16_t framesCount = MaxFrameCount;
   bool isStackCaptured = (_stackFrameCollector.CaptureStack(
-      pThreadInfo->GetOsThreadHandle(), frames, framesCount, isTruncated
+      pThreadInfo->GetOsThreadHandle(),
+      seedContext,
+      frames,
+      framesCount,
+      isTruncated
   ));
   // resume the thread before doing any allocation that could cause a deadlock
   ::ResumeThread(pThreadInfo->GetOsThreadHandle());

--- a/src/dd-win-prof/StackSamplerLoop.cpp
+++ b/src/dd-win-prof/StackSamplerLoop.cpp
@@ -237,8 +237,11 @@ void StackSamplerLoop::CollectOneThreadSample(
   // Suspend the thread AND grab its CONTEXT in one shot. The CONTEXT acts both
   // as the suspend-fence (per Raymond Chen) and as the unwind seed below, so we
   // pay for a single GetThreadContext per sample instead of two.
-  CONTEXT seedContext;
-  if (!_stackFrameCollector.TrySuspendThread(pThreadInfo, seedContext)) {
+  // The CONTEXT is ~1.2 KB on x64; we keep a single instance on the stack and
+  // let CaptureStack mutate it in place (RtlVirtualUnwind rewrites the
+  // register state frame-by-frame) instead of copying it.
+  CONTEXT threadContext;
+  if (!_stackFrameCollector.TrySuspendThread(pThreadInfo, threadContext)) {
     return;
   }
 
@@ -246,7 +249,7 @@ void StackSamplerLoop::CollectOneThreadSample(
   uint64_t frames[MaxFrameCount];
   uint16_t framesCount = MaxFrameCount;
   bool isStackCaptured = (_stackFrameCollector.CaptureStack(
-      pThreadInfo->GetOsThreadHandle(), seedContext, frames, framesCount, isTruncated
+      pThreadInfo->GetOsThreadHandle(), threadContext, frames, framesCount, isTruncated
   ));
   // resume the thread before doing any allocation that could cause a deadlock
   ::ResumeThread(pThreadInfo->GetOsThreadHandle());

--- a/src/dd-win-prof/StackSamplerLoop.cpp
+++ b/src/dd-win-prof/StackSamplerLoop.cpp
@@ -240,8 +240,8 @@ void StackSamplerLoop::CollectOneThreadSample(
   // The CONTEXT is ~1.2 KB on x64; we keep a single instance on the stack and
   // let CaptureStack mutate it in place (RtlVirtualUnwind rewrites the
   // register state frame-by-frame) instead of copying it.
-  CONTEXT threadContext;
-  if (!_stackFrameCollector.TrySuspendThread(pThreadInfo, threadContext)) {
+  CONTEXT seedContext;
+  if (!_stackFrameCollector.TrySuspendThread(pThreadInfo, seedContext)) {
     return;
   }
 
@@ -249,7 +249,7 @@ void StackSamplerLoop::CollectOneThreadSample(
   uint64_t frames[MaxFrameCount];
   uint16_t framesCount = MaxFrameCount;
   bool isStackCaptured = (_stackFrameCollector.CaptureStack(
-      pThreadInfo->GetOsThreadHandle(), threadContext, frames, framesCount, isTruncated
+      pThreadInfo->GetOsThreadHandle(), seedContext, frames, framesCount, isTruncated
   ));
   // resume the thread before doing any allocation that could cause a deadlock
   ::ResumeThread(pThreadInfo->GetOsThreadHandle());

--- a/src/dd-win-prof/StackSamplerLoop.cpp
+++ b/src/dd-win-prof/StackSamplerLoop.cpp
@@ -246,11 +246,7 @@ void StackSamplerLoop::CollectOneThreadSample(
   uint64_t frames[MaxFrameCount];
   uint16_t framesCount = MaxFrameCount;
   bool isStackCaptured = (_stackFrameCollector.CaptureStack(
-      pThreadInfo->GetOsThreadHandle(),
-      seedContext,
-      frames,
-      framesCount,
-      isTruncated
+      pThreadInfo->GetOsThreadHandle(), seedContext, frames, framesCount, isTruncated
   ));
   // resume the thread before doing any allocation that could cause a deadlock
   ::ResumeThread(pThreadInfo->GetOsThreadHandle());


### PR DESCRIPTION
## What

Each stack sample currently calls `GetThreadContext` **twice** on the suspended target thread:

1. `TrySuspendThread` -> `EnsureThreadIsSuspended` does `GetThreadContext(CONTEXT_INTEGER)` purely as a fence to drain the asynchronous `SuspendThread` ([Raymond Chen](https://devblogs.microsoft.com/oldnewthing/20150205-00/?p=44743)).
2. `CaptureStack` does `GetThreadContext(CONTEXT_FULL)` to get the unwind seed for `RtlVirtualUnwind`.

A successful `GetThreadContext` already provides the suspend-drain guarantee, so call (1) is redundant.

## How

- `TrySuspendThread` now takes an out `CONTEXT&` and fills it with `CONTEXT_FULL`. The successful fetch acts as the suspend fence.
- `CaptureStack` takes a `const CONTEXT&` seed instead of querying the thread itself. It works on a local copy because `RtlVirtualUnwind` mutates the context as it walks frames.
- `StackSamplerLoop` owns the `CONTEXT` on the stack and threads it through both calls. `ResumeThread` responsibility is unchanged.
- `EnsureThreadIsSuspended` helper removed.

## Effect

Per-sample syscall budget on the hot path drops from `SuspendThread` + `GetThreadContext`×2 + `ResumeThread` to `SuspendThread` + `GetThreadContext` + `ResumeThread`. One full user→kernel transition saved per sampled thread per tick.

## Risk

- No semantic change: same `CONTEXT_FULL` seed, same suspend/resume sequence, single production caller updated.
- ABI: `StackFrameCollector` is internal, no external surface changes.
- Test overload `CaptureStack(uint32_t tid, ...)` (returns false today) untouched.

## Follow-ups

- Branch `r1viollet/cheap-thread-state` (separate work) drops `NtQueryInformationThread` from the hot path and stacks on top of this cleanly.
- Lock-wait correctness test will land separately.