### PR TITLE
[PROF-15030] fix(obfsymbols): skip zero-RVA symbols in non-OMAP path

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,10 +25,22 @@ jobs:
         key: deps-${{ hashFiles('src/CMakeLists.txt') }}
 
     - name: Configure CMake
-      run: cmake -G "Visual Studio 17 2022" -A x64 -B build -DFETCHCONTENT_BASE_DIR=${{ github.workspace }}/.deps
+      run: cmake -G "Visual Studio 17 2022" -A x64 -B build -DDD_WIN_PROF_BUILD_OBFUSCATION=ON -DFETCHCONTENT_BASE_DIR=${{ github.workspace }}/.deps
 
     - name: Build
       run: cmake --build build --config ${{ matrix.configuration }}
+
+    - name: Validate Runner symbol file
+      shell: pwsh
+      run: |
+        $config  = "${{ matrix.configuration }}"
+        $obfExe  = "build/obfuscation/ObfSymbols/$config/ObfSymbols.exe"
+        $pdb     = "build/src/Runner/$config/Runner.pdb"
+        $symFile = "build/src/Runner/$config/Runner.sym"
+        Write-Host "Generating $symFile ..."
+        & $obfExe --pdb $pdb --out $symFile
+        if ($LASTEXITCODE -ne 0) { Write-Error "ObfSymbols failed (exit $LASTEXITCODE)"; exit 1 }
+        pwsh e2e-tests/validate-runner-sym.ps1 -SymFile $symFile
 
     - name: Run tests
       run: build/src/Tests/${{ matrix.configuration }}/Tests.exe

--- a/e2e-tests/validate-runner-sym.ps1
+++ b/e2e-tests/validate-runner-sym.ps1
@@ -1,0 +1,56 @@
+# Validate Runner.sym: checks MODULE header format and zero-RVA regression.
+# Run after ObfSymbols to catch symbolication issues before E2E scenarios.
+
+param([Parameter(Mandatory)][string]$SymFile)
+
+$ErrorActionPreference = "Stop"
+
+if (-not (Test-Path $SymFile)) {
+    Write-Error "Symbol file not found: $SymFile"
+}
+
+$lines = Get-Content $SymFile
+if ($lines.Count -eq 0) {
+    Write-Error "Symbol file is empty"
+}
+
+Write-Host "[INFO] Validating $SymFile ($($lines.Count) lines)" -ForegroundColor Cyan
+
+# ============================================================================
+# MODULE header format
+# ============================================================================
+$header = $lines[0]
+if ($header -notmatch '^MODULE\s+windows\s+x86_64\s+[0-9A-F]{32,}\s+Runner\.exe$') {
+    Write-Error "Invalid MODULE header: $header"
+}
+Write-Host "[PASS] MODULE header format" -ForegroundColor Green
+
+# ============================================================================
+# Zero-RVA regression: symbols at RVA 0 act as catch-all in symbolizer
+# ============================================================================
+$zeroRva = $lines | Where-Object { $_ -match '^(PUBLIC|PRIVATE)\s+0\s+' }
+if ($zeroRva.Count -gt 0) {
+    Write-Error "Found $($zeroRva.Count) zero-RVA entries (these corrupt flamegraphs):`n  $(($zeroRva | Select-Object -First 3) -join "`n  ")"
+}
+Write-Host "[PASS] No zero-RVA entries" -ForegroundColor Green
+
+# ============================================================================
+# Key Runner scenario functions
+# ============================================================================
+$required = @(
+    @('SimpleCalls',        '\bSimpleCalls\(\)'),
+    @('Spin',               '\bSpin\(int\)'),
+    @('ThreadFunction1',    '\bThreadFunction1\(void\*\)'),
+    @('RunWaitingThreads',  '\bRunWaitingThreads\(\)'),
+    @('main',               '\bmain\(int')
+)
+
+foreach ($fn in $required) {
+    $name, $pattern = $fn
+    if (-not ($lines | Where-Object { $_ -match $pattern })) {
+        Write-Error "Missing symbol: $name (pattern: $pattern)"
+    }
+}
+Write-Host "[PASS] All required symbols present" -ForegroundColor Green
+
+Write-Host "`n[SUCCESS] Validation passed" -ForegroundColor Green

--- a/obfuscation/ObfSymbols/PdbParser.cpp
+++ b/obfuscation/ObfSymbols/PdbParser.cpp
@@ -415,7 +415,7 @@ bool PdbParser::ExtractModuleInfo(ModuleInfo& moduleInfo) {
     swprintf_s(
         buildIdStr,
         80,
-        L"%08x%04x%04x%02x%02x%02x%02x%02x%02x%02x%02x%x",
+        L"%08X%04X%04X%02X%02X%02X%02X%02X%02X%02X%02X%X",
         guid.Data1,
         guid.Data2,
         guid.Data3,
@@ -752,6 +752,11 @@ bool PdbParser::ExtractSymbols(std::vector<SymbolInfo>& symbols) {
       }
     } else {
       rvaOptimized = rvaOriginal;
+      if (rvaOptimized == 0) {
+        skippedSymbols++;
+        pSymbol.Release();
+        continue;
+      }
       sizeOptimized = static_cast<ULONG>(sizeOriginal);
     }
 
@@ -838,6 +843,11 @@ bool PdbParser::ExtractSymbols(std::vector<SymbolInfo>& symbols) {
         sizeOptimized = CalculateSizeWithOMAP(rvaOriginal, sizeOriginal);
       } else {
         rvaOptimized = rvaOriginal;
+        if (rvaOptimized == 0) {
+          publicSymbolsSkipped++;
+          pPublicSymbol.Release();
+          continue;
+        }
         sizeOptimized = static_cast<ULONG>(sizeOriginal);
       }
 


### PR DESCRIPTION
## Description

Skip symbols with RVA 0 in the non-OMAP code paths of `PdbParser::ExtractSymbols` (both function and public symbol loops). The OMAP path already had this guard; this mirrors it in the non-OMAP else branches.

Also uppercase the build ID format string (`%08X`) to match the runtime profiler (`Symbolication.cpp`).

## Motivation

A symbol at RVA 0 acts as a catch-all in Breakpad sym files: any address that cannot be resolved falls back to the closest preceding entry. With a zero-RVA entry, that entry wins for everything, making the entire flamegraph show the same obfuscated name instead of "Unknown Function".

Root cause: non-OMAP builds (no LTO/LTCG) did not run the zero-RVA guard that was present in the OMAP branch.

## Testing

- Simplified `e2e-tests/validate-runner-sym.ps1` (56 lines): checks MODULE header format, zero-RVA regression, and key Runner scenario functions
- Simplified `obfuscation/test.ps1` (90 lines, down from 540): smoke test that builds TestSymbolsDll, runs ObfSymbols, validates zero-RVA + obfuscated name format
- CI now builds ObfSymbols, generates `Runner.sym`, and runs the validator before unit tests

## Changes

- `obfuscation/ObfSymbols/PdbParser.cpp`: add zero-RVA checks to non-OMAP paths (6 lines), uppercase build ID format
- `e2e-tests/validate-runner-sym.ps1`: new validator script
- `obfuscation/test.ps1`: simplified from 540 to 90 lines
- `.github/workflows/test.yml`: add Runner.sym validation step