### PR TITLE
[PROF-15030] Use FUNC records for Breakpad symbol files

### DIFF
--- a/obfuscation/ObfSymbols/ObfSymbols.cpp
+++ b/obfuscation/ObfSymbols/ObfSymbols.cpp
@@ -77,8 +77,13 @@ void WriteSymbolLine(
     const std::wstring& obfuscatedName,
     bool includeSignature
 ) {
-  stream << (symbol.isPublic ? L"PUBLIC" : L"PRIVATE") << L" " << std::hex << symbol.rva
-         << L" " << std::hex << symbol.size << L" " << obfuscatedName;
+  // Use FUNC records instead of PUBLIC/PRIVATE - symbolic library supports FUNC via session.functions()
+  // Format: FUNC <rva> <size> <param_size> <name>
+  // param_size is the size of parameters on stack (0 if unknown)
+  stream << L"FUNC" << L" " << std::hex << symbol.rva
+         << L" " << std::hex << symbol.size
+         << L" 0"  // param_size - unknown, use 0
+         << L" " << obfuscatedName;
 
   if (includeSignature) {
     stream << L" " << (!symbol.signature.empty() ? symbol.signature : symbol.name);

--- a/obfuscation/ObfSymbols/ObfSymbols.cpp
+++ b/obfuscation/ObfSymbols/ObfSymbols.cpp
@@ -77,12 +77,12 @@ void WriteSymbolLine(
     const std::wstring& obfuscatedName,
     bool includeSignature
 ) {
-  // Use FUNC records instead of PUBLIC/PRIVATE - symbolic library supports FUNC via session.functions()
+  // Use FUNC records instead of PUBLIC/PRIVATE.
+  // The symbolic library supports FUNC via session.functions().
   // Format: FUNC <rva> <size> <param_size> <name>
-  // param_size is the size of parameters on stack (0 if unknown)
-  stream << L"FUNC" << L" " << std::hex << symbol.rva
-         << L" " << std::hex << symbol.size
-         << L" 0"  // param_size - unknown, use 0
+  // param_size is the size of parameters on stack; use 0 if unknown.
+  stream << L"FUNC" << L" " << std::hex << symbol.rva << L" " << std::hex << symbol.size
+         << L" 0"  // param_size - unknown
          << L" " << obfuscatedName;
 
   if (includeSignature) {

--- a/obfuscation/test.ps1
+++ b/obfuscation/test.ps1
@@ -204,7 +204,7 @@ Test-Condition "Both files have same line count" ($symbolLines.Count -eq $obfLin
 
 Write-Info "Found $($symbolLines.Count) lines (includes MODULE header)"
 
-# Test: Symbol file format (PUBLIC/PRIVATE ADDRESS SIZE SymbolName)
+# Test: Symbol file format (FUNC ADDRESS SIZE PARAM_SIZE SymbolName)
 # Note: Addresses are hex without 0x prefix
 $invalidSymbolLines = @()
 $addresses = @()
@@ -217,15 +217,15 @@ foreach ($line in $symbolLines) {
         continue
     }
 
-    if ($line -match '^(PUBLIC|PRIVATE)\s+([0-9a-fA-F]+)\s+([0-9a-fA-F]+)\s+(.+)$') {
-        $visibility = $matches[1]
-        $address = $matches[2]
-        $size = $matches[3]
+    if ($line -match '^FUNC\s+([0-9a-fA-F]+)\s+([0-9a-fA-F]+)\s+([0-9a-fA-F]+)\s+(.+)$') {
+        $address = $matches[1]
+        $size = $matches[2]
+        $paramSize = $matches[3]
         $symbolName = $matches[4]
         $addresses += [Convert]::ToInt64($address, 16)
 
-        # Count visibility types
-        if ($visibility -eq "PUBLIC") { $publicCount++ } else { $privateCount++ }
+        # All FUNC records counted as public (they're all exported functions)
+        $publicCount++
 
         # Validate address is hex
         if ($address -notmatch '^[0-9a-fA-F]+$') {
@@ -234,6 +234,11 @@ foreach ($line in $symbolLines) {
 
         # Validate size is hex
         if ($size -notmatch '^[0-9a-fA-F]+$') {
+            $invalidSymbolLines += $line
+        }
+
+        # Validate param_size is hex
+        if ($paramSize -notmatch '^[0-9a-fA-F]+$') {
             $invalidSymbolLines += $line
         }
 
@@ -269,7 +274,7 @@ Test-Condition "Addresses are sorted in ascending order" $addressesSorted `
 # ============================================================================
 Write-TestHeader "Validating Obfuscated Symbol File Format"
 
-# Test: Obfuscated file format (PUBLIC/PRIVATE ADDRESS SIZE obf_XXXXXXXX)
+# Test: Obfuscated file format (FUNC ADDRESS SIZE PARAM_SIZE obf_XXXXXXXX)
 # Note: Obfuscated file does NOT include real symbol names
 # Note: Addresses are hex without 0x prefix
 $invalidObfLines = @()
@@ -284,17 +289,17 @@ foreach ($line in $obfLines) {
         continue
     }
 
-    if ($line -match '^(PUBLIC|PRIVATE)\s+([0-9a-fA-F]+)\s+([0-9a-fA-F]+)\s+(obf_[0-9A-F]{8})$') {
-        $visibility = $matches[1]
-        $address = $matches[2]
-        $size = $matches[3]
+    if ($line -match '^FUNC\s+([0-9a-fA-F]+)\s+([0-9a-fA-F]+)\s+([0-9a-fA-F]+)\s+(obf_[0-9A-F]{8})$') {
+        $address = $matches[1]
+        $size = $matches[2]
+        $paramSize = $matches[3]
         $obfName = $matches[4]
 
         $obfNames += $obfName
         $obfAddresses += [Convert]::ToInt64($address, 16)
 
-        # Count visibility types
-        if ($visibility -eq "PUBLIC") { $obfPublicCount++ } else { $obfPrivateCount++ }
+        # All FUNC records counted as public
+        $obfPublicCount++
 
         # Validate address is hex
         if ($address -notmatch '^[0-9a-fA-F]+$') {
@@ -367,25 +372,25 @@ if ($symbolLines.Count -gt 1) {
         $symbolLine = $symbolLines[$idx]
         $obfLine = $obfLines[$idx]
 
-        if ($symbolLine -match '^(PUBLIC|PRIVATE)\s+([0-9a-fA-F]+)\s+([0-9a-fA-F]+)\s+(.+)$') {
-            $symVisibility = $matches[1]
-            $symAddress = $matches[2]
-            $symSize = $matches[3]
+        if ($symbolLine -match '^FUNC\s+([0-9a-fA-F]+)\s+([0-9a-fA-F]+)\s+([0-9a-fA-F]+)\s+(.+)$') {
+            $symAddress = $matches[1]
+            $symSize = $matches[2]
+            $symParamSize = $matches[3]
             $symName = $matches[4]
 
-            # Extract obfuscated name from symbol line (it's the first space-separated token after size)
+            # Extract obfuscated name from symbol line (it's the first space-separated token after param_size)
             $symObfName = if ($symName -match '^(obf_[0-9A-F]{8})\s+') { $matches[1] } else { "" }
 
-            if ($obfLine -match '^(PUBLIC|PRIVATE)\s+([0-9a-fA-F]+)\s+([0-9a-fA-F]+)\s+(obf_[0-9A-F]{8})$') {
-                $obfVisibility = $matches[1]
-                $obfAddress = $matches[2]
-                $obfSize = $matches[3]
+            if ($obfLine -match '^FUNC\s+([0-9a-fA-F]+)\s+([0-9a-fA-F]+)\s+([0-9a-fA-F]+)\s+(obf_[0-9A-F]{8})$') {
+                $obfAddress = $matches[1]
+                $obfSize = $matches[2]
+                $obfParamSize = $matches[3]
                 $obfName = $matches[4]
 
-                # Test: Visibility matches
-                $visibilityMatch = ($symVisibility -eq $obfVisibility)
-                Test-Condition "Line $idx : Visibility matches" $visibilityMatch `
-                    "Symbol file: $symVisibility, Obfuscated file: $obfVisibility"
+                # Test: Param size matches
+                $paramSizeMatch = ($symParamSize -eq $obfParamSize)
+                Test-Condition "Line $idx : Param size matches" $paramSizeMatch `
+                    "Symbol file: $symParamSize, Obfuscated file: $obfParamSize"
 
                 # Test: Addresses match
                 $addressesMatch = ($symAddress -eq $obfAddress)


### PR DESCRIPTION
## Summary

Changes ObfSymbols to emit FUNC records instead of PUBLIC/PRIVATE for Breakpad symbol files.

## Motivation

The `symbolic` library (used by `deobfuscation-api`) supports FUNC records via `session.functions() → ToSymCache()` but does NOT support PRIVATE records. PRIVATE is a non-standard Breakpad extension.

Using FUNC matches the official Breakpad spec and works with upstream symbolic without requiring fork patches.
**Why I did not put everything as public?**
Yes this would have worked. But it was not semantically correct.

## Changes

- `obfuscation/ObfSymbols/ObfSymbols.cpp`: emit `FUNC <rva> <size> 0 <name>` instead of `PRIVATE <rva> <size> <name>`

## Testing

- ✅ Local test with symbolic library: all 8 test RVAs return correct symbols
- ✅ Uploaded to staging, captured profile (build ID FDA5BF9510B746CA8882DC3DCFA453C41)
- ✅ Flamegraph shows correct obf_ symbols (~23% each for Spin, SimpleCalls, main, __scrt_common_main_seh)
- ✅ No phantom symbols, no unknown functions

## Follow-up

Frontend symbol loading feature may need updates for FUNC format (tracked separately).

## Related

- JIRA: PROF-15030
- Builds on: #56 (zero-RVA fix)