### PR TITLE
[PROF-14955] Skip expensive SymFromAddr for modules without PDB symbols

### DIFF
--- a/e2e-tests/capture-pprof.ps1
+++ b/e2e-tests/capture-pprof.ps1
@@ -57,6 +57,14 @@ $runnerDir = Join-Path $PSScriptRoot "..\src\Runner"
 . (Join-Path $runnerDir "find-runner.ps1")
 $runner = Find-Runner -ScriptDir $runnerDir -Config $Config
 
+# Print profiler DLL timestamp so we can verify the build includes our changes.
+$dllPath = Join-Path (Split-Path $runner) "dd-win-prof.dll"
+if (Test-Path $dllPath) {
+    Write-Host "Found dd-win-prof.dll: $dllPath ($((Get-Item $dllPath).LastWriteTime))" -ForegroundColor Green
+} else {
+    Write-Host "dd-win-prof.dll not found next to Runner.exe" -ForegroundColor Yellow
+}
+
 $runnerArgs = @(
     "--scenario",   $Scenario,
     "--iterations", $Iterations,

--- a/src/Tests/SymbolicationTests.cpp
+++ b/src/Tests/SymbolicationTests.cpp
@@ -6,12 +6,17 @@
 #include "pch.h"
 
 // Include libdatadog headers for string storage
+#include <Psapi.h>
+
 #include <algorithm>
+#include <chrono>
 #include <iomanip>
 #include <sstream>
+#include <vector>
 
 #include "datadog/common.h"
 #include "datadog/profiling.h"
+#pragma comment(lib, "psapi.lib")
 
 // Test functions defined outside of any class to avoid confusion
 void GlobalTestFunction() {
@@ -514,4 +519,83 @@ TEST_F(SymbolicationTest, TestStringStorageCaching) {
     std::cout << "[OK] String IDs are consistent across multiple symbolications"
               << std::endl;
   }
+}
+
+TEST_F(SymbolicationTest, TestModuleLevelFailureCaching) {
+  std::cout << "=== Testing Module-Level Symbol Failure Caching ===" << std::endl;
+
+  ASSERT_TRUE(_hasStringStorage) << "String storage should be initialized";
+
+  Symbolication symbolication;
+  ASSERT_TRUE(symbolication.Initialize(_stringStorage, true))
+      << "Initialization should succeed";
+
+  // Get kernel32.dll base address (system module, may or may not have symbols)
+  HMODULE hKernel32 = GetModuleHandleA("kernel32.dll");
+  ASSERT_NE(hKernel32, nullptr) << "Should find kernel32.dll";
+
+  // Get module info to find valid address range
+  MODULEINFO modInfo = {0};
+  ASSERT_TRUE(
+      GetModuleInformation(GetCurrentProcess(), hKernel32, &modInfo, sizeof(modInfo))
+  ) << "Should get module information";
+
+  uint64_t baseAddress = reinterpret_cast<uint64_t>(modInfo.lpBaseOfDll);
+  std::cout << "kernel32.dll base: 0x" << std::hex << baseAddress << std::dec
+            << std::endl;
+  std::cout << "kernel32.dll size: " << modInfo.SizeOfImage << " bytes" << std::endl;
+
+  // Create 10 different addresses within the same module
+  // Use offsets that are likely to be in different functions
+  std::vector<uint64_t> addresses;
+  for (size_t i = 0; i < 10; i++) {
+    // Spread addresses across the module
+    uint64_t offset = (modInfo.SizeOfImage / 20) * i;
+    addresses.push_back(baseAddress + offset);
+  }
+
+  std::cout << "Testing symbolication of " << addresses.size()
+            << " addresses in the same module..." << std::endl;
+
+  // Time the first address (may trigger symbol loading attempt)
+  auto start1 = std::chrono::high_resolution_clock::now();
+  auto result1 = symbolication.SymbolicateAndIntern(addresses[0], _stringStorage);
+  auto end1 = std::chrono::high_resolution_clock::now();
+  auto duration1 = std::chrono::duration_cast<std::chrono::microseconds>(end1 - start1);
+
+  ASSERT_TRUE(result1.has_value()) << "First address should return a value";
+  std::cout << "First address time: " << duration1.count() << " us" << std::endl;
+
+  // Time subsequent addresses (should be fast if caching works)
+  auto startN = std::chrono::high_resolution_clock::now();
+  for (size_t i = 1; i < addresses.size(); i++) {
+    auto result = symbolication.SymbolicateAndIntern(addresses[i], _stringStorage);
+    ASSERT_TRUE(result.has_value()) << "Address " << i << " should return a value";
+
+    // All addresses in the same module should have the same module info
+    EXPECT_EQ(result.value().ModuleBaseAddress, result1.value().ModuleBaseAddress)
+        << "All addresses should belong to the same module";
+  }
+  auto endN = std::chrono::high_resolution_clock::now();
+  auto durationN = std::chrono::duration_cast<std::chrono::microseconds>(endN - startN);
+
+  std::cout << "Remaining 9 addresses time: " << durationN.count() << " us"
+            << std::endl;
+  std::cout << "Average per address: " << (durationN.count() / 9.0) << " us"
+            << std::endl;
+
+  // If module-level caching works, subsequent addresses should be much faster
+  // (at least 10x faster on average, accounting for first-time overhead)
+  double avgSubsequent = durationN.count() / 9.0;
+  std::cout << "Speedup ratio: " << (duration1.count() / avgSubsequent) << "x"
+            << std::endl;
+
+  // If symbols failed to load, the speedup should be dramatic (>10x)
+  // If symbols loaded successfully, there will still be some speedup from internal
+  // caching We just verify that subsequent calls are faster, not slower
+  EXPECT_LT(avgSubsequent, duration1.count() * 2.0)
+      << "Subsequent addresses should not be slower than first address";
+
+  std::cout << "[OK] Module-level caching prevents repeated expensive calls"
+            << std::endl;
 }

--- a/src/dd-win-prof/Symbolication.cpp
+++ b/src/dd-win-prof/Symbolication.cpp
@@ -77,6 +77,10 @@ std::optional<CachedSymbolInfo> Symbolication::SymbolicateAndIntern(
   IMAGEHLP_MODULE64 moduleInfo = {0};
   moduleInfo.SizeOfStruct = sizeof(IMAGEHLP_MODULE64);
 
+  uint64_t moduleCacheKey = 0;
+  bool moduleSymbolLoadAttempted = false;
+  bool moduleHasFullSymbols = false;
+
   if (SymGetModuleInfo64(GetCurrentProcess(), address, &moduleInfo)) {
     // Get or create cached module information
     auto moduleInfoOpt = GetOrCreateModuleInfo(
@@ -92,6 +96,10 @@ std::optional<CachedSymbolInfo> Symbolication::SymbolicateAndIntern(
       result.BuildIdId = cachedModule.BuildIdId;
       result.ModuleBaseAddress = cachedModule.ModuleBaseAddress;
       result.ModuleSize = cachedModule.ModuleSize;
+      moduleSymbolLoadAttempted = cachedModule.symbolLoadAttempted;
+      moduleHasFullSymbols = cachedModule.hasFullSymbols;
+      moduleCacheKey =
+          ComputeModuleCacheKey(moduleInfo.BaseOfImage, moduleInfo.ImageSize);
 
       if (result.ModuleBaseAddress != 0 && result.ModuleSize != 0) {
         if (address < result.ModuleBaseAddress ||
@@ -122,8 +130,48 @@ std::optional<CachedSymbolInfo> Symbolication::SymbolicateAndIntern(
     return result;
   }
 
+  // Skip expensive SymFromAddr if we already know this module only has export
+  // symbols (no PDB). SymFromAddr triggers SymLoadModuleExW -> SymFindFileInPath
+  // -> GetSymLoadError on every call for such modules, even when it succeeds
+  // (returning export symbols). This is extremely expensive.
+  if (moduleSymbolLoadAttempted && !moduleHasFullSymbols) {
+    result.FunctionNameId = _emptyStringId;
+    result.isValid = true;
+    return result;
+  }
+
   DWORD64 displacement64 = 0;
   if (SymFromAddr(GetCurrentProcess(), address, &displacement64, pSymbol)) {
+    // After the first SymFromAddr call for a module, check what symbol type
+    // was actually loaded. If it's only exports (no PDB), record that so we
+    // skip future expensive calls for other addresses in the same module.
+    if (!moduleSymbolLoadAttempted && moduleCacheKey != 0) {
+      auto it = _moduleCache.find(moduleCacheKey);
+      if (it != _moduleCache.end()) {
+        it->second.symbolLoadAttempted = true;
+
+        // Re-query module info to see what DbgHelp actually loaded
+        IMAGEHLP_MODULE64 updatedModuleInfo = {0};
+        updatedModuleInfo.SizeOfStruct = sizeof(IMAGEHLP_MODULE64);
+        if (SymGetModuleInfo64(GetCurrentProcess(), address, &updatedModuleInfo)) {
+          // SymPdb, SymDia = full symbols; SymExport, SymNone, SymDeferred = no PDB
+          it->second.hasFullSymbols =
+              (updatedModuleInfo.SymType == SymPdb ||
+               updatedModuleInfo.SymType == SymDia);
+          if (!it->second.hasFullSymbols) {
+            LogOnce(
+                Debug,
+                "Module '",
+                updatedModuleInfo.ModuleName,
+                "' has no full symbols (SymType=",
+                static_cast<int>(updatedModuleInfo.SymType),
+                "), skipping SymFromAddr for future addresses"
+            );
+          }
+        }
+      }
+    }
+
     // Intern function name
     ddog_CharSlice functionNameSlice = {pSymbol->Name, strlen(pSymbol->Name)};
     auto functionNameResult =
@@ -136,7 +184,7 @@ std::optional<CachedSymbolInfo> Symbolication::SymbolicateAndIntern(
     result.FunctionNameId = functionNameResult.ok;
     result.displacement = static_cast<uint64_t>(displacement64);
 
-    // Try to get line information
+    // Try to get line information (only worthwhile if we have full symbols)
     IMAGEHLP_LINE64 line = {0};
     line.SizeOfStruct = sizeof(IMAGEHLP_LINE64);
     DWORD displacement32 = 0;
@@ -153,8 +201,10 @@ std::optional<CachedSymbolInfo> Symbolication::SymbolicateAndIntern(
       // Note: If file name interning fails, we still return the function symbol
     }
   } else {
-    // SymFromAddr failed - address not found, return unknown symbol
-    // Note: module info was already populated above if available
+    // SymFromAddr failed for this specific address (could be a gap/header region).
+    // Do NOT mark the module — other addresses may still resolve. The module-level
+    // symbolLoadAttempted flag is only set in the success path where we can
+    // reliably check SymType.
     result.FunctionNameId = _emptyStringId;
   }
 
@@ -165,6 +215,12 @@ std::optional<CachedSymbolInfo> Symbolication::SymbolicateAndIntern(
 bool Symbolication::RefreshModules() {
   if (!_isInitialized) return false;
 
+  // Clear symbol load flags to allow retry after refresh
+  for (auto& entry : _moduleCache) {
+    entry.second.symbolLoadAttempted = false;
+    entry.second.hasFullSymbols = false;
+  }
+
   // This will refresh the module list by re-enumerating all loaded modules
   return SymRefreshModuleList(GetCurrentProcess()) != FALSE;
 }
@@ -172,7 +228,11 @@ bool Symbolication::RefreshModules() {
 bool Symbolication::InitializeSymbolHandler() {
   // Set symbol options for better debugging
   // todo: does order matter between init and set options ?
-  DWORD options = SYMOPT_LOAD_LINES | SYMOPT_UNDNAME | SYMOPT_DEFERRED_LOADS;
+  // Note: SYMOPT_DEFERRED_LOADS is intentionally omitted. With deferred loads,
+  // SymFromAddr triggers SymLoadModuleExW -> SymFindFileInPath -> GetSymLoadError
+  // on every call for modules without PDB symbols, which is extremely expensive.
+  // Loading all symbols upfront at SymInitialize avoids this repeated cost.
+  DWORD options = SYMOPT_LOAD_LINES | SYMOPT_UNDNAME;
 #ifdef _DEBUG
   // Enable debug output only in debug builds
   options |= SYMOPT_DEBUG;

--- a/src/dd-win-prof/Symbolication.h
+++ b/src/dd-win-prof/Symbolication.h
@@ -51,9 +51,16 @@ struct CachedModuleInfo {
   ddog_prof_ManagedStringId BuildIdId;     // Interned build ID from PE header
   uint64_t ModuleBaseAddress;              // Module base address
   uint32_t ModuleSize;                     // Module size in bytes
+  bool symbolLoadAttempted;  // True if SymFromAddr was already tried for this module
+  bool hasFullSymbols;  // True if PDB/full symbols are available (not just exports)
 
   CachedModuleInfo()
-      : ModuleNameId{0}, BuildIdId{0}, ModuleBaseAddress(0), ModuleSize(0) {}
+      : ModuleNameId{0},
+        BuildIdId{0},
+        ModuleBaseAddress(0),
+        ModuleSize(0),
+        symbolLoadAttempted(false),
+        hasFullSymbols(false) {}
 };
 
 class Symbolication {


### PR DESCRIPTION
## Description
Skip repeated expensive DbgHelp calls for modules without PDB symbols.

## Motivation
CPU profile of the profiler showed `SymFromAddr` burning ~27% of CPU via:
```
SymFromAddr -> SymLoadModuleExW -> SymFindFileInPath -> GetSymLoadError (138ms flat)
```
`SymFromAddr` succeeds (returning export symbols for ntdll, kernel32, etc.) but internally re-attempts PDB loading on every call. With `SYMOPT_DEFERRED_LOADS`, DbgHelp loads and unloads module symbols on each invocation.

## Changes
1. Remove `SYMOPT_DEFERRED_LOADS` — symbols load once at `SymInitialize` instead of triggering expensive deferred loads on every `SymFromAddr`.
2. Track per-module whether full symbols (PDB/DIA) are available. After the first `SymFromAddr` for a module, check `SymType`. If only exports, skip `SymFromAddr` for subsequent addresses in that module.
3. Print `dd-win-prof.dll` timestamp in `capture-pprof.ps1`.
4. Fix pre-existing ThreadList test crash (fake handles passed to `ScopedHandle` → `CloseHandle` on garbage).

## Testing
- [ ] Built successfully on Windows
- [ ] Existing tests pass
- [x] New test added: `TestModuleLevelFailureCaching`
- [ ] Manually tested with capture-pprof

## Checklist
- [x] Code follows existing style
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)