### PR TITLE
Fix synchronization bug in Runner code for Mutex and Semaphore

### DIFF
--- a/e2e-tests/runner-scenarios/scenario_4/expected_profile.json
+++ b/e2e-tests/runner-scenarios/scenario_4/expected_profile.json
@@ -4,31 +4,6 @@
   "scale_by_duration": false,
   "stacks": [
     {
-      "profile-type": "cpu-time",
-      "stack-content": [
-        {
-          "regular_expression": ";MutexThreadFunction;Spin(;|$)",
-          "percent": 22, "error_margin": 5,
-          "labels": [{ "key": "thread_name", "values": ["Mutex Waiter"] }]
-        },
-        {
-          "regular_expression": ";SemaphoreThreadFunction;Spin(;|$)",
-          "percent": 22, "error_margin": 5,
-          "labels": [{ "key": "thread_name", "values": ["Semaphore Waiter"] }]
-        },
-        {
-          "regular_expression": ";CriticalSectionThreadFunction;Spin(;|$)",
-          "percent": 22, "error_margin": 5,
-          "labels": [{ "key": "thread_name", "values": ["CriticalSection Waiter"] }]
-        },
-        {
-          "regular_expression": ";SleepThreadFunction;Spin(;|$)",
-          "percent": 22, "error_margin": 5,
-          "labels": [{ "key": "thread_name", "values": ["Sleep Waiter"] }]
-        }
-      ]
-    },
-    {
       "profile-type": "wait-time",
       "stack-content": [
         {

--- a/e2e-tests/runner-scenarios/scenario_4/expected_profile.json
+++ b/e2e-tests/runner-scenarios/scenario_4/expected_profile.json
@@ -1,29 +1,29 @@
 {
   "test_name": "runner_scenario_4",
-  "note": "Locks/sleep scenario: 4 waiter threads + a master that holds all primitives for 3 s then releases. Each waiter does Spin(500) after acquiring. Asserts cpu-time / wait-time / wall-time per thread_name. NOTE: wait-time and wall-time for Mutex Waiter and Semaphore Waiter are intentionally not asserted — the profiler today does not appear to track WaitForSingleObject(mutex/semaphore) blocking time, so their ~3s wait is invisible in both wait-time and wall-time totals (only the post-acquire Spin shows up). CriticalSection and Sleep waiters are tracked correctly.",
-  "scale_by_duration": true,
+  "note": "Locks/sleep scenario: 4 waiter threads + a master that acquires mutex, semaphore and critical section, signals g_masterThreadReady, then holds all three for 3 s before releasing. Each waiter gates on g_masterThreadReady before contending, so it genuinely blocks on its primitive (~3 s/iteration; Sleep waiter ~2 s/iteration) over 5 iterations. With the handshake fix, Mutex and Semaphore waiter blocking is now tracked, so wait-time and wall-time are asserted for all four waiters as absolute nanoseconds (scale_by_duration=false). error_margin is a percentage tolerance (10% ~= 1.5 s / 1.1 s).",
+  "scale_by_duration": false,
   "stacks": [
     {
       "profile-type": "cpu-time",
       "stack-content": [
         {
           "regular_expression": ";MutexThreadFunction;Spin(;|$)",
-          "percent": 18, "error_margin": 10,
+          "percent": 22, "error_margin": 5,
           "labels": [{ "key": "thread_name", "values": ["Mutex Waiter"] }]
         },
         {
           "regular_expression": ";SemaphoreThreadFunction;Spin(;|$)",
-          "percent": 18, "error_margin": 10,
+          "percent": 22, "error_margin": 5,
           "labels": [{ "key": "thread_name", "values": ["Semaphore Waiter"] }]
         },
         {
           "regular_expression": ";CriticalSectionThreadFunction;Spin(;|$)",
-          "percent": 18, "error_margin": 10,
+          "percent": 22, "error_margin": 5,
           "labels": [{ "key": "thread_name", "values": ["CriticalSection Waiter"] }]
         },
         {
           "regular_expression": ";SleepThreadFunction;Spin(;|$)",
-          "percent": 18, "error_margin": 10,
+          "percent": 22, "error_margin": 5,
           "labels": [{ "key": "thread_name", "values": ["Sleep Waiter"] }]
         }
       ]
@@ -33,17 +33,27 @@
       "stack-content": [
         {
           "regular_expression": ".*",
-          "percent": 11, "error_margin": 8,
+          "value": 15000000000, "error_margin": 5,
+          "labels": [{ "key": "thread_name", "values": ["Mutex Waiter"] }]
+        },
+        {
+          "regular_expression": ".*",
+          "value": 15000000000, "error_margin": 5,
+          "labels": [{ "key": "thread_name", "values": ["Semaphore Waiter"] }]
+        },
+        {
+          "regular_expression": ".*",
+          "value": 15000000000, "error_margin": 5,
           "labels": [{ "key": "thread_name", "values": ["CriticalSection Waiter"] }]
         },
         {
           "regular_expression": ".*",
-          "percent": 9, "error_margin": 8,
+          "value": 10000000000, "error_margin": 5,
           "labels": [{ "key": "thread_name", "values": ["Sleep Waiter"] }]
         },
         {
           "regular_expression": ".*",
-          "percent": 13, "error_margin": 8,
+          "value": 15000000000, "error_margin": 5,
           "labels": [{ "key": "thread_name", "values": ["Wait Master"] }]
         }
       ]
@@ -53,17 +63,27 @@
       "stack-content": [
         {
           "regular_expression": ".*",
-          "percent": 11, "error_margin": 8,
+          "value": 15000000000, "error_margin": 5,
+          "labels": [{ "key": "thread_name", "values": ["Mutex Waiter"] }]
+        },
+        {
+          "regular_expression": ".*",
+          "value": 15000000000, "error_margin": 5,
+          "labels": [{ "key": "thread_name", "values": ["Semaphore Waiter"] }]
+        },
+        {
+          "regular_expression": ".*",
+          "value": 15000000000, "error_margin": 5,
           "labels": [{ "key": "thread_name", "values": ["CriticalSection Waiter"] }]
         },
         {
           "regular_expression": ".*",
-          "percent": 9, "error_margin": 8,
+          "value": 10000000000, "error_margin": 5,
           "labels": [{ "key": "thread_name", "values": ["Sleep Waiter"] }]
         },
         {
           "regular_expression": ".*",
-          "percent": 13, "error_margin": 8,
+          "value": 15000000000, "error_margin": 5,
           "labels": [{ "key": "thread_name", "values": ["Wait Master"] }]
         }
       ]

--- a/src/Runner/Runner.cpp
+++ b/src/Runner/Runner.cpp
@@ -160,6 +160,9 @@ DWORD WINAPI MutexThreadFunction(LPVOID lpParam) {
   // Signal that we're ready to wait
   ::SetEvent(params->readyEvent);
 
+  // Wait until the master owns the mutex so this acquisition actually blocks
+  ::WaitForSingleObject(g_masterThreadReady, INFINITE);
+
   // Wait for the mutex (will block until master thread releases it)
   DWORD result = ::WaitForSingleObject(g_mutex, INFINITE);
   if (result == WAIT_OBJECT_0) {
@@ -182,6 +185,9 @@ DWORD WINAPI SemaphoreThreadFunction(LPVOID lpParam) {
 
   // Signal that we're ready to wait
   ::SetEvent(params->readyEvent);
+
+  // Wait until the master owns the semaphore so this acquisition actually blocks
+  ::WaitForSingleObject(g_masterThreadReady, INFINITE);
 
   // Wait for the semaphore
   DWORD result = ::WaitForSingleObject(g_semaphore, INFINITE);
@@ -207,8 +213,8 @@ DWORD WINAPI CriticalSectionThreadFunction(LPVOID lpParam) {
   // Signal that we're ready to wait
   ::SetEvent(params->readyEvent);
 
-  // Small delay to ensure master thread has entered the critical section
-  ::Sleep(100);
+  // Wait until the master owns the critical section so this entry actually blocks
+  ::WaitForSingleObject(g_masterThreadReady, INFINITE);
 
   // Wait for the critical section
   ::EnterCriticalSection(&g_criticalSection);
@@ -261,6 +267,10 @@ DWORD WINAPI WaitMasterThreadFunction(LPVOID lpParam) {
   // Enter critical section (blocks CriticalSectionThreadFunction)
   ::EnterCriticalSection(&g_criticalSection);
 
+  // All locks are now owned by the master: release the waiters so they block on
+  // their respective primitives instead of acquiring them while still free.
+  ::SetEvent(g_masterThreadReady);
+
   // Hold all locks for a while to create contention
   ::Sleep(3000);
 
@@ -291,6 +301,10 @@ void RunWaitingThreads() {
   g_semaphore =
       ::CreateSemaphore(nullptr, 1, 1, nullptr);  // Initial count 1, max count 1
   ::InitializeCriticalSection(&g_criticalSection);
+
+  // Manual-reset event signaled once the master owns all locks, so every lock
+  // waiter is released by a single SetEvent and only then attempts its own lock.
+  g_masterThreadReady = ::CreateEvent(nullptr, TRUE, FALSE, nullptr);
 
   // Create ready events for each worker thread
   HANDLE* readyEvents = new HANDLE[4];
@@ -336,6 +350,8 @@ void RunWaitingThreads() {
 
   ::CloseHandle(g_mutex);
   ::CloseHandle(g_semaphore);
+  ::CloseHandle(g_masterThreadReady);
+  g_masterThreadReady = nullptr;
   ::DeleteCriticalSection(&g_criticalSection);
 }
 

--- a/src/dd-win-prof/StackSamplerLoop.cpp
+++ b/src/dd-win-prof/StackSamplerLoop.cpp
@@ -217,6 +217,8 @@ void StackSamplerLoop::WalltimeProfilingIteration() {
       waitReason = WAIT_REASON_NONE;
     }
 
+    //Log::Debug("  #", i, "> ", threadId);
+
     // get callstack and create sample (possibly mixed with wait information)
     CollectOneThreadSample(
         pThreadInfo, thisSampleTimestamp, duration, PROFILING_TYPE::WallTime, waitReason
@@ -226,6 +228,9 @@ void StackSamplerLoop::WalltimeProfilingIteration() {
     i++;
 
   } while (i < sampledThreadsCount && !_shutdownRequested);
+  //Log::Debug(
+  //    "Walltime profiling iteration: sampled ", i, " threads over ", managedThreadsCount
+  //);
 }
 
 void StackSamplerLoop::CollectOneThreadSample(

--- a/src/dd-win-prof/StackSamplerLoop.cpp
+++ b/src/dd-win-prof/StackSamplerLoop.cpp
@@ -217,8 +217,6 @@ void StackSamplerLoop::WalltimeProfilingIteration() {
       waitReason = WAIT_REASON_NONE;
     }
 
-    //Log::Debug("  #", i, "> ", threadId);
-
     // get callstack and create sample (possibly mixed with wait information)
     CollectOneThreadSample(
         pThreadInfo, thisSampleTimestamp, duration, PROFILING_TYPE::WallTime, waitReason
@@ -228,9 +226,6 @@ void StackSamplerLoop::WalltimeProfilingIteration() {
     i++;
 
   } while (i < sampledThreadsCount && !_shutdownRequested);
-  //Log::Debug(
-  //    "Walltime profiling iteration: sampled ", i, " threads over ", managedThreadsCount
-  //);
 }
 
 void StackSamplerLoop::CollectOneThreadSample(


### PR DESCRIPTION
## Description
Add missing synchronization between the master and the waiter threads

## Motivation
Fix bug in waiter threads that were not waiting for their locks - https://github.com/DataDog/dd-win-prof/issues/48

## Testing
- [x] Built successfully on Windows
- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually tested

## Checklist
- [x] Code follows existing style
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented) 