### PR TITLE
[PROF-14955] Simplify transport config: API key implies agentless

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,10 @@ Define your configuration in a `ProfilerConfig` instance and pass it to `SetupPr
 
 #### Agentless (direct to Datadog)
 
+When `DD_API_KEY` is set, profiling data is sent directly to the Datadog intake without requiring a local Datadog Agent.
+
 - `DD_SERVICE=your-app-name` - Application name
-- `DD_PROFILING_AGENTLESS=1` - Enable agentless mode
-- `DD_SITE=datadoghq.com` - Datadog site (varies by region)
+- `DD_SITE=datadoghq.com` - Datadog site (varies by region, defaults to `datadoghq.com`)
 - `DD_API_KEY=your-api-key` - Your Datadog API key
 
 #### Optional (recommended)
@@ -129,7 +130,6 @@ Define your configuration in a `ProfilerConfig` instance and pass it to `SetupPr
 **Agentless via env vars:**
 ```bash
 DD_SERVICE=my-windows-app
-DD_PROFILING_AGENTLESS=1
 DD_SITE=datadoghq.com
 DD_API_KEY=your_datadog_api_key_here
 DD_VERSION=1.2.3

--- a/src/Tests/ConfigurationTests.cpp
+++ b/src/Tests/ConfigurationTests.cpp
@@ -52,6 +52,8 @@ class ConfigurationTest : public ::testing::Test {
     SaveEnvVar(EnvironmentVariables::ServiceName);
     SaveEnvVar(EnvironmentVariables::AgentHost);
     SaveEnvVar(EnvironmentVariables::ApiKey);
+    SaveEnvVar(EnvironmentVariables::Site);
+    SaveEnvVar(EnvironmentVariables::AgentUrl);
   }
 
   void TearDown() override {
@@ -195,8 +197,7 @@ TEST_F(ConfigurationTest, ConfigurationCanBeOverriden) {
   EXPECT_EQ(config.CpuWallTimeSamplingPeriod(), 100ms);
   EXPECT_EQ(config.GetApiKey(), "xxx-xxxx-xxxxx");
   EXPECT_EQ(config.GetSite(), "http://localhost:8126");
-  EXPECT_TRUE(config.IsAgentless())
-      << "Should be in agentless mode when endpoint is set";
+  EXPECT_TRUE(config.IsAgentless()) << "Should be agentless when API key is set";
 }
 
 // ===========================================================================
@@ -471,4 +472,44 @@ TEST_F(ConfigurationTest, InitConfig_NoEnvVars_False_EnvVarsPreserved) {
   EXPECT_EQ(config.GetEnvironment(), "env-env")
       << "Env var value should survive when noEnvVars=false";
   EXPECT_EQ(config.GetServiceName(), "api-svc") << "API override should apply";
+}
+
+// ===========================================================================
+// Agentless mode: derived from DD_API_KEY presence
+// ===========================================================================
+
+TEST_F(ConfigurationTest, Agentless_ApiKeyAndSite) {
+  SetTestEnvVar(EnvironmentVariables::ApiKey, "my-api-key");
+  SetTestEnvVar(EnvironmentVariables::Site, "datadoghq.eu");
+
+  Configuration config;
+  EXPECT_TRUE(config.IsAgentless());
+  EXPECT_EQ(config.GetSite(), "datadoghq.eu");
+}
+
+TEST_F(ConfigurationTest, Agentless_ApiKeyOnly_DefaultSite) {
+  UnsetTestEnvVar(EnvironmentVariables::Site);
+  SetTestEnvVar(EnvironmentVariables::ApiKey, "my-api-key");
+
+  Configuration config;
+  // DD_SITE unset → defaults to datadoghq.com → agentless
+  EXPECT_TRUE(config.IsAgentless());
+  EXPECT_EQ(config.GetSite(), "datadoghq.com");
+}
+
+TEST_F(ConfigurationTest, Agent_NoApiKey) {
+  UnsetTestEnvVar(EnvironmentVariables::ApiKey);
+
+  Configuration config;
+  EXPECT_FALSE(config.IsAgentless());
+}
+
+TEST_F(ConfigurationTest, ValidateTransport_ConflictingConfig_Fails) {
+  SetTestEnvVar(EnvironmentVariables::ApiKey, "my-api-key");
+  SetTestEnvVar(EnvironmentVariables::AgentUrl, "http://localhost:8126");
+
+  Configuration config;
+  EXPECT_TRUE(config.IsAgentless());
+  EXPECT_FALSE(config.ValidateTransportConfig())
+      << "Should reject conflicting agent + agentless settings";
 }

--- a/src/dd-win-prof/Configuration.cpp
+++ b/src/dd-win-prof/Configuration.cpp
@@ -31,13 +31,7 @@ void Configuration::SetEnvironmentName(const char* environmentName) {
 
 void Configuration::SetVersion(const char* version) { _version = version; }
 
-void Configuration::SetEndpoint(const char* url) {
-  //_agentUrl = url;
-  _site = url;
-
-  // force agentless mode when setting the full URL
-  _isAgentLess = true;
-}
+void Configuration::SetEndpoint(const char* url) { _site = url; }
 
 void Configuration::SetApiKey(const char* apiKey) { _apiKey = apiKey; }
 
@@ -61,7 +55,6 @@ void Configuration::InitDefaults() {
   _walltimeThreadsThreshold = DefaultWalltimeThreadsThreshold;
   _cpuThreadsThreshold = DefaultCpuThreadsThreshold;
   _apiKey = DefaultEmptyString;
-  _isAgentLess = false;
   _agentUrl = DefaultEmptyString;
   _agentHost = DefaultAgentHost;
   _agentPort = DefaultAgentPort;
@@ -107,7 +100,6 @@ Configuration::Configuration() {
   _cpuThreadsThreshold = ExtractCpuThreadsThreshold();
   _apiKey = GetEnvironmentValue(EnvironmentVariables::ApiKey, DefaultEmptyString);
 
-  _isAgentLess = GetEnvironmentValue(EnvironmentVariables::Agentless, false);
   _agentUrl = GetEnvironmentValue(EnvironmentVariables::AgentUrl, DefaultEmptyString);
   _agentHost = GetEnvironmentValue(EnvironmentVariables::AgentHost, DefaultAgentHost);
   _agentPort = GetEnvironmentValue(EnvironmentVariables::AgentPort, DefaultAgentPort);
@@ -323,7 +315,21 @@ std::string const& Configuration::GetAgentHost() const { return _agentHost; }
 
 int32_t Configuration::GetAgentPort() const { return _agentPort; }
 
-bool Configuration::IsAgentless() const { return _isAgentLess; }
+bool Configuration::IsAgentless() const { return !_apiKey.empty(); }
+
+bool Configuration::ValidateTransportConfig() const {
+  bool hasAgentSettings = !_agentUrl.empty() || _agentHost != DefaultAgentHost ||
+                          _agentPort != DefaultAgentPort;
+  if (IsAgentless() && hasAgentSettings) {
+    Log::Error(
+        "Conflicting transport config: DD_API_KEY is set (agentless) but agent "
+        "settings (DD_TRACE_AGENT_URL / DD_AGENT_HOST / DD_TRACE_AGENT_PORT) are "
+        "also configured. Remove one or the other."
+    );
+    return false;
+  }
+  return true;
+}
 
 std::string const& Configuration::GetSite() const { return _site; }
 

--- a/src/dd-win-prof/Configuration.h
+++ b/src/dd-win-prof/Configuration.h
@@ -24,7 +24,10 @@ class Configuration {
   std::string const& GetAgentUrl() const;
   std::string const& GetAgentHost() const;
   int32_t GetAgentPort() const;
+  // Agentless mode is derived: true when an API key is configured.
   bool IsAgentless() const;
+  // Returns false and logs an error if agent and agentless settings conflict.
+  bool ValidateTransportConfig() const;
   std::string const& GetSite() const;
   std::string const& GetApiKey() const;
   std::string const& GetServiceName() const;
@@ -126,7 +129,7 @@ class Configuration {
   std::string _site;
   std::string _namedPipeName;
   tags _userTags;
-  bool _isAgentLess;
+
   std::chrono::nanoseconds _cpuWallTimeSamplingPeriod;
   int32_t _walltimeThreadsThreshold;
   int32_t _cpuThreadsThreshold;

--- a/src/dd-win-prof/EnvironmentVariables.h
+++ b/src/dd-win-prof/EnvironmentVariables.h
@@ -26,13 +26,12 @@ class EnvironmentVariables final {
   constexpr static const char* Environment = "DD_ENV";
   constexpr static const char* Site = "DD_SITE";
   constexpr static const char* UploadInterval = "DD_PROFILING_UPLOAD_PERIOD";
-  constexpr static const char* AgentUrl = "DD_TRACE_AGENT_UR";
+  constexpr static const char* AgentUrl = "DD_TRACE_AGENT_URL";
   constexpr static const char* AgentHost = "DD_AGENT_HOST";
   constexpr static const char* AgentPort = "DD_TRACE_AGENT_PORT";
   constexpr static const char* NamedPipeName = "DD_TRACE_PIPE_NAME";
   constexpr static const char* ApiKey = "DD_API_KEY";
   constexpr static const char* Hostname = "DD_HOSTNAME";
-  constexpr static const char* Agentless = "DD_PROFILING_AGENTLESS";
   constexpr static const char* Tags = "DD_TAGS";
 
   constexpr static const char* ProfilesOutputDir = "DD_INTERNAL_PROFILING_OUTPUT_DIR";

--- a/src/dd-win-prof/ProfileExporter.cpp
+++ b/src/dd-win-prof/ProfileExporter.cpp
@@ -76,8 +76,7 @@ ProfileExporter::ProfileExporter(
     _exportEnabled =
         _pConfiguration->IsExportEnabled();  // Use dedicated export setting
     _apiKey = _pConfiguration->GetApiKey();
-    _agentMode = !_pConfiguration
-                      ->IsAgentless();  // Use agent mode unless agentless is specified
+    _agentMode = !_pConfiguration->IsAgentless();
   }
 }
 

--- a/src/dd-win-prof/Profiler.cpp
+++ b/src/dd-win-prof/Profiler.cpp
@@ -38,6 +38,10 @@ bool Profiler::StartProfiling() {
     return false;
   }
 
+  if (!_pConfiguration->ValidateTransportConfig()) {
+    return false;
+  }
+
   Log::Info("Starting profiler...");
 
   auto valueTypeProvider = SampleValueTypeProvider();


### PR DESCRIPTION
## Description
Agentless mode is now derived from `DD_API_KEY` being set, matching the existing CLI behavior (`SetEndpoint`). `DD_PROFILING_AGENTLESS` env var is removed.

Also fixes `DD_TRACE_AGENT_UR` typo → `DD_TRACE_AGENT_URL`.

## Changes
- `IsAgentless()` = `!_apiKey.empty()` — no more `_isAgentLess` field
- `DD_PROFILING_AGENTLESS` removed
- If both API key and agent settings are configured, warn and use agentless
- `ValidateTransportConfig()` called at config finalization (constructor + `InitializeConfiguration`)
- README updated

## Testing
- [x] Built successfully on Windows
- [x] Existing tests pass
- [x] New tests added: `Agentless_ApiKeyAndSite`, `Agentless_ApiKeyOnly_DefaultSite`, `Agent_NoApiKey`, `ValidateTransport_ConflictingConfig_UsesAgentless`
- [x] Manually tested

## Checklist
- [x] Code follows existing style
- [x] Documentation updated
- [x] No breaking changes