### PR TITLE
[PROF-14955] Bump version.h to 0.4.0

### DIFF
--- a/src/dd-win-prof/version.h
+++ b/src/dd-win-prof/version.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #define DLL_VERSION_MAJOR 0
-#define DLL_VERSION_MINOR 3
+#define DLL_VERSION_MINOR 4
 #define DLL_VERSION_PATCH 0
 #define DLL_VERSION_BUILD 0
 


### PR DESCRIPTION
## Description

Bump `src/dd-win-prof/version.h` from `0.3.0` to `0.4.0` so `main` is ready for the next release cycle. v0.3.0 was tagged and released from the previous state of `main`.

## Motivation

Per the *Cutting a release* doc in the README: `main` always sits at the version about to be released. After tagging `v0.3.0`, `main` needs to be moved onto the next dev version. The DLL's VS_VERSION_INFO now follows `version.h` automatically (#63), so this single edit propagates to both the header and the compiled binary.

Ticket: [PROF-14955](https://datadoghq.atlassian.net/browse/PROF-14955) (parent epic).

## Testing

- [x] `version.h` parses cleanly
- [ ] Built successfully on Windows
- [ ] Existing tests pass

## Checklist
- [x] Code follows existing style
- [x] No breaking changes


[PROF-14955]: https://datadoghq.atlassian.net/browse/PROF-14955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ